### PR TITLE
Feature: enable monitoring_prom feature in CI actions

### DIFF
--- a/stacks-core/cache/build-cache/action.yml
+++ b/stacks-core/cache/build-cache/action.yml
@@ -71,6 +71,7 @@ runs:
         cargo nextest archive \
           --build-jobs 8 \
           --workspace \
+          --features monitoring_prom \
           --tests \
           --locked \
           --archive-file ~/test_archive.tar.zst
@@ -88,6 +89,7 @@ runs:
         cd testnet/stacks-node && cargo nextest archive \
           --build-jobs 8 \
           --workspace \
+          --features monitoring_prom \
           --tests \
           --locked \
           --features prod-genesis-chainstate \

--- a/stacks-core/run-tests/action.yml
+++ b/stacks-core/run-tests/action.yml
@@ -40,6 +40,7 @@ runs:
           --verbose \
           --archive-file ${{ inputs.archive-file }} \
           --test-threads ${{ inputs.threads }} \
+          --features monitoring_prom \
           --retries ${{ inputs.retries }} \
           --run-ignored all \
           --fail-fast \

--- a/stacks-core/run-tests/partition/action.yml
+++ b/stacks-core/run-tests/partition/action.yml
@@ -44,6 +44,7 @@ runs:
           --retries ${{ inputs.retries }} \
           --final-status-level ${{ inputs.status-level }} \
           --fail-fast \
+          --features monitoring_prom \
           --success-output ${{ inputs.success-output }} \
           --status-level ${{ inputs.status-level }} \
           --archive-file ${{ inputs.archive-file }} \


### PR DESCRIPTION
This enables the prometheus feature flag in the CI tests. This way, the test coverage we have for the prometheus metrics will run in CI.