### PR TITLE
Move Shells from Main Workflow to Composite Action

### DIFF
--- a/mutation-testing/check-packages-and-shards/README.md
+++ b/mutation-testing/check-packages-and-shards/README.md
@@ -1,0 +1,28 @@
+# Check Packages and Shards action
+
+Checks whether to run mutants on big (`stackslib`/`stacks-node`) or small packages (all others), and whether to run them using strategy matrix or not.
+
+## Documentation
+
+### Outputs
+| Output | Description |
+| ------------------------------- | ----------------------------------------------------- |
+| `run_big_packages` | True if there are mutants on `stackslib` or `stacks-node` packages, false otherwise.
+| `big_packages_with_shards` | True if there are more than 15 mutants on big packages.
+| `run_small_packages` | True if there are mutants on small packages, false otherwise.
+| `small_packages_with_shards` | True if there are more than 79 (119 if `big_packages_with_shards` is true) mutants on small packages.
+
+## Usage
+
+```yaml
+name: Action
+on: pull-request
+jobs:
+  check-packages-and-shards:
+    name: Check Packages and Shards
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Packages and Shards
+        id: check_packages_and_shards
+        uses: stacks-network/actions/mutation-testing/check-packages-and-shards@main
+```

--- a/mutation-testing/check-packages-and-shards/action.yml
+++ b/mutation-testing/check-packages-and-shards/action.yml
@@ -55,7 +55,7 @@ runs:
         fi
 
         # Reverse the file, remove 4 lines after '+++ /dev/null', then reverse it back (editors can't go backwards - to remove lines above)
-        tac "$input_file" > "$temp_file"
+        tac "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
         sed '/+++ \/dev\/null/{n;N;N;N;d;}' "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
         tac "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
 

--- a/mutation-testing/check-packages-and-shards/action.yml
+++ b/mutation-testing/check-packages-and-shards/action.yml
@@ -58,11 +58,8 @@ runs:
         cargo mutants --in-diff git.diff --list > all_mutants.txt
         mkdir -p mutants_by_packages
 
-        cat git.diff
-        cat all_mutants.txt
-
         # Check that the file exists before performing actions on it
-        if [ -s all_mutants.txt ]; then
+        if [ ! -s all_mutants.txt ]; then
           echo "The file containing mutants is missing or empty!"
           exit 1
         fi

--- a/mutation-testing/check-packages-and-shards/action.yml
+++ b/mutation-testing/check-packages-and-shards/action.yml
@@ -1,10 +1,14 @@
 name: Check Packages and Shards
 
 outputs:
-  run_big_packages: ${{ steps.check_packages_and_shards.outputs.run_big_packages }}
-  big_packages_with_shards: ${{ steps.check_packages_and_shards.outputs.big_packages_with_shards }}
-  run_small_packages: ${{ steps.check_packages_and_shards.outputs.run_small_packages }}
-  small_packages_with_shards: ${{ steps.check_packages_and_shards.outputs.small_packages_with_shards }}
+  run_big_packages:
+    value: ${{ steps.check_packages_and_shards.outputs.run_big_packages }}
+  big_packages_with_shards:
+    value: ${{ steps.check_packages_and_shards.outputs.big_packages_with_shards }}
+  run_small_packages:
+    value: ${{ steps.check_packages_and_shards.outputs.run_small_packages }}
+  small_packages_with_shards:
+    value: ${{ steps.check_packages_and_shards.outputs.small_packages_with_shards }}
 
 runs:
   using: "composite"

--- a/mutation-testing/check-packages-and-shards/action.yml
+++ b/mutation-testing/check-packages-and-shards/action.yml
@@ -1,0 +1,119 @@
+name: Check Packages and Shards
+
+outputs:
+  run_big_packages: ${{ steps.check_packages_and_shards.outputs.run_big_packages }}
+  big_packages_with_shards: ${{ steps.check_packages_and_shards.outputs.big_packages_with_shards }}
+  run_small_packages: ${{ steps.check_packages_and_shards.outputs.run_small_packages }}
+  small_packages_with_shards: ${{ steps.check_packages_and_shards.outputs.small_packages_with_shards }}
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: Checkout stacks-core repo
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Install cargo-mutants
+      shell: bash
+      run: cargo install --version 23.12.2 cargo-mutants
+
+    - name: Relative diff
+      shell: bash
+      run: |
+        git diff origin/${{ github.base_ref }}.. > git.diff
+
+    - name: Update git diff
+      shell: bash
+      run: |
+        input_file="git.diff"
+        temp_file="temp_diff_file.diff"
+
+        # Check if the commands exist on the host
+        for cmd in tac awk sed; do
+          command -v "${cmd}" > /dev/null 2>&1 || echo "Missing command: ${cmd}"
+        done
+
+        # Reverse the file, remove 4 lines after '+++ /dev/null', then reverse it back (editors can't go backwards - to remove lines above)
+        tac "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
+        sed '/+++ \/dev\/null/{n;N;N;N;d;}' "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
+        tac "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
+
+        # Remove the lines between '+++ /dev/null' (included) and 'diff --git a/'
+        awk '
+          BEGIN { in_block=0 }
+          /\+\+\+ \/dev\/null/ { in_block=1; next }
+          in_block && /diff --git a\// { in_block=0; print; next }
+          !in_block
+        ' "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
+
+    - name: Split diffs
+      shell: bash
+      run: |
+        cargo mutants --in-diff git.diff --list > all_mutants.txt
+        mkdir -p mutants_by_packages
+
+        # Check that the file exists before performing actions on it
+        if [ -s all_mutants.txt ]; then
+          echo "The file containing mutants is missing or empty!"
+          exit 1
+        fi
+
+        # Split the differences from git into 2 parts, big packages ('stacks-node' and 'stackslib') and small packages (all others) and put them into separate files
+        while IFS= read -r line; do
+          package=$(echo "$line" | cut -d'/' -f1)
+          if [[ $package == "testnet" || $package == "stackslib" ]]; then
+            echo "$line" >> "mutants_by_packages/big_packages.txt"
+          else
+            echo "$line" >> "mutants_by_packages/small_packages.txt"
+          fi
+        done < all_mutants.txt
+
+    - name: Check packages and shards
+      id: check_packages_and_shards
+      shell: bash
+      run: |
+        number_of_big_mutants=0
+        number_of_small_mutants=0
+
+        # If big_packages file exists, count how many mutants there are
+        if [[ -s mutants_by_packages/big_packages.txt ]]; then
+          number_of_big_mutants=$(cat mutants_by_packages/big_packages.txt | awk 'END { print NR }' | tr -d '[:space:]')
+        fi
+
+        # If small_packages file exists, count how many mutants there are
+        if [[ -s mutants_by_packages/small_packages.txt ]]; then
+          number_of_small_mutants=$(cat mutants_by_packages/small_packages.txt | awk 'END { print NR }' | tr -d '[:space:]')
+        fi
+
+        # Set the mutants limit for when to run with shards on the small packages
+        if [[ $number_of_big_mutants -gt 15 ]]; then
+          small_packages_shard_limit=119
+        else
+          small_packages_shard_limit=79
+        fi
+
+        # If there are mutants from big packages, check whether to run with or without shards, otherwise there's nothing to run
+        if [[ $number_of_big_mutants -ne 0 ]]; then
+          echo "run_big_packages=true" >> "$GITHUB_OUTPUT"
+          if [[ $number_of_big_mutants -gt 15 ]]; then
+            echo "big_packages_with_shards=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "big_packages_with_shards=false" >> "$GITHUB_OUTPUT"
+          fi
+        else
+          echo "run_big_packages=false" >> "$GITHUB_OUTPUT"
+        fi
+
+        # If there are mutants from small packages, check whether to run with or without shards, otherwise there's nothing to run
+        if [[ $number_of_small_mutants -ne 0 ]]; then
+          echo "run_small_packages=true" >> "$GITHUB_OUTPUT"
+          if [[ $number_of_small_mutants -gt $small_packages_shard_limit ]]; then
+            echo "small_packages_with_shards=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "small_packages_with_shards=false" >> "$GITHUB_OUTPUT"
+          fi
+        else
+          echo "run_small_packages=false" >> "$GITHUB_OUTPUT"
+        fi

--- a/mutation-testing/check-packages-and-shards/action.yml
+++ b/mutation-testing/check-packages-and-shards/action.yml
@@ -59,12 +59,6 @@ runs:
         sed '/+++ \/dev\/null/{n;N;N;N;d;}' "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
         tac "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
 
-        # Check that the file exists before performing actions on it
-        if [ ! -s "$temp_file" ]; then
-          echo "Diff file missing!"
-          exit 1
-        fi
-
         # Remove the lines between '+++ /dev/null' (included) and 'diff --git a/'
         awk '
           BEGIN { in_block=0 }

--- a/mutation-testing/check-packages-and-shards/action.yml
+++ b/mutation-testing/check-packages-and-shards/action.yml
@@ -58,8 +58,8 @@ runs:
         cargo mutants --in-diff git.diff --list > all_mutants.txt
         mkdir -p mutants_by_packages
 
-        echo git.diff
-        echo all_mutants.txt
+        cat git.diff
+        cat all_mutants.txt
 
         # Check that the file exists before performing actions on it
         if [ -s all_mutants.txt ]; then

--- a/mutation-testing/check-packages-and-shards/action.yml
+++ b/mutation-testing/check-packages-and-shards/action.yml
@@ -58,6 +58,9 @@ runs:
         cargo mutants --in-diff git.diff --list > all_mutants.txt
         mkdir -p mutants_by_packages
 
+        echo git.diff
+        echo all_mutants.txt
+
         # Check that the file exists before performing actions on it
         if [ -s all_mutants.txt ]; then
           echo "The file containing mutants is missing or empty!"

--- a/mutation-testing/check-packages-and-shards/action.yml
+++ b/mutation-testing/check-packages-and-shards/action.yml
@@ -1,13 +1,21 @@
 name: Check Packages and Shards
+description: "Checks which types of packages are contained in the diffs and how many mutants there are"
+branding:
+  icon: "check"
+  color: "gray-dark"
 
 outputs:
   run_big_packages:
+    description: "True if there are packages on `stackslib` or `stacks-node`."
     value: ${{ steps.check_packages_and_shards.outputs.run_big_packages }}
   big_packages_with_shards:
+    description: "True if there are more than 16 mutants on `stackslib` and `stacks-node`."
     value: ${{ steps.check_packages_and_shards.outputs.big_packages_with_shards }}
   run_small_packages:
+    description: "True if there are packages on other packages than `stackslib` or `stacks-node`."
     value: ${{ steps.check_packages_and_shards.outputs.run_small_packages }}
   small_packages_with_shards:
+    description: "True if there are more than 79 (119 if `big_packages_with_shards` is true) mutants on small packages."
     value: ${{ steps.check_packages_and_shards.outputs.small_packages_with_shards }}
 
 runs:
@@ -15,13 +23,14 @@ runs:
 
   steps:
     - name: Checkout stacks-core repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         fetch-depth: 0
 
-    - name: Install cargo-mutants
-      shell: bash
-      run: cargo install --version 23.12.2 cargo-mutants
+    - uses: taiki-e/install-action@ac89944b5b150d78567ab6c02badfbe48b0b55aa # v2.20.16
+        name: Install cargo-mutants
+        with:
+          tool: cargo-mutants@23.12.2 # v23.12.2
 
     - name: Relative diff
       shell: bash
@@ -36,13 +45,25 @@ runs:
 
         # Check if the commands exist on the host
         for cmd in tac awk sed; do
-          command -v "${cmd}" > /dev/null 2>&1 || echo "Missing command: ${cmd}"
+          command -v "${cmd}" > /dev/null 2>&1 || { echo "Missing command: ${cmd}" && exit 1; }
         done
 
+        # Check that the file exists before performing actions on it
+        if [ ! -s "$input_file" ]; then
+          echo "Diff file missing!"
+          exit 1
+        fi
+
         # Reverse the file, remove 4 lines after '+++ /dev/null', then reverse it back (editors can't go backwards - to remove lines above)
-        tac "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
+        tac "$input_file" > "$temp_file"
         sed '/+++ \/dev\/null/{n;N;N;N;d;}' "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
         tac "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
+
+        # Check that the file exists before performing actions on it
+        if [ ! -s "$temp_file" ]; then
+          echo "Diff file missing!"
+          exit 1
+        fi
 
         # Remove the lines between '+++ /dev/null' (included) and 'diff --git a/'
         awk '
@@ -50,11 +71,28 @@ runs:
           /\+\+\+ \/dev\/null/ { in_block=1; next }
           in_block && /diff --git a\// { in_block=0; print; next }
           !in_block
-        ' "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
+        ' "$input_file" > "$temp_file"
+
+        # Check that the file exists before performing actions on it
+        if [ -s "$temp_file" ]; then
+          mv "$temp_file" "$input_file"
+        else
+          echo "Temp diff file missing!"
+          exit 1
+        fi
+
+        exit 0
 
     - name: Split diffs
       shell: bash
       run: |
+        # Check that the file exists before performing actions on it
+        if [ ! -s git.diff ]; then
+          echo "Diff file missing!"
+          exit 1
+        fi
+
+        # Make a file containing all the mutants for the differences in the PR and a folder to split them into big and small packages
         cargo mutants --in-diff git.diff --list > all_mutants.txt
         mkdir -p mutants_by_packages
 
@@ -67,12 +105,17 @@ runs:
         # Split the differences from git into 2 parts, big packages ('stacks-node' and 'stackslib') and small packages (all others) and put them into separate files
         while IFS= read -r line; do
           package=$(echo "$line" | cut -d'/' -f1)
-          if [[ $package == "testnet" || $package == "stackslib" ]]; then
-            echo "$line" >> "mutants_by_packages/big_packages.txt"
-          else
-            echo "$line" >> "mutants_by_packages/small_packages.txt"
-          fi
+          case $package in
+            "testnet" | "stackslib")
+              echo "$line" >> "mutants_by_packages/big_packages.txt"
+              ;;
+            *)
+              echo "$line" >> "mutants_by_packages/small_packages.txt"
+              ;;
+          esac
         done < all_mutants.txt
+
+        exit 0
 
     - name: Check packages and shards
       id: check_packages_and_shards
@@ -92,22 +135,19 @@ runs:
         fi
 
         # Set the mutants limit for when to run with shards on the small packages
+        # If there are mutants from big packages, check whether to run with or without shards, otherwise there's nothing to run
         if [[ $number_of_big_mutants -gt 15 ]]; then
           small_packages_shard_limit=119
+          echo "run_big_packages=true" >> "$GITHUB_OUTPUT"
+          echo "big_packages_with_shards=true" >> "$GITHUB_OUTPUT"
         else
           small_packages_shard_limit=79
-        fi
-
-        # If there are mutants from big packages, check whether to run with or without shards, otherwise there's nothing to run
-        if [[ $number_of_big_mutants -ne 0 ]]; then
-          echo "run_big_packages=true" >> "$GITHUB_OUTPUT"
-          if [[ $number_of_big_mutants -gt 15 ]]; then
-            echo "big_packages_with_shards=true" >> "$GITHUB_OUTPUT"
-          else
+          if [[ $number_of_big_mutants -ne 0 ]]; then
+            echo "run_big_packages=true" >> "$GITHUB_OUTPUT"
             echo "big_packages_with_shards=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_big_packages=false" >> "$GITHUB_OUTPUT"
           fi
-        else
-          echo "run_big_packages=false" >> "$GITHUB_OUTPUT"
         fi
 
         # If there are mutants from small packages, check whether to run with or without shards, otherwise there's nothing to run
@@ -121,3 +161,5 @@ runs:
         else
           echo "run_small_packages=false" >> "$GITHUB_OUTPUT"
         fi
+
+        exit 0

--- a/mutation-testing/check-packages-and-shards/action.yml
+++ b/mutation-testing/check-packages-and-shards/action.yml
@@ -28,9 +28,9 @@ runs:
         fetch-depth: 0
 
     - uses: taiki-e/install-action@ac89944b5b150d78567ab6c02badfbe48b0b55aa # v2.20.16
-        name: Install cargo-mutants
-        with:
-          tool: cargo-mutants@23.12.2 # v23.12.2
+      name: Install cargo-mutants
+      with:
+        tool: cargo-mutants@23.12.2 # v23.12.2
 
     - name: Relative diff
       shell: bash

--- a/mutation-testing/output-pr-mutants/README.md
+++ b/mutation-testing/output-pr-mutants/README.md
@@ -1,0 +1,18 @@
+# Output PR Mutants action
+
+Write the mutants tested in the previous jobs of the same workflow to github step summary.
+
+## Usage
+
+```yaml
+name: Action
+on: push
+jobs:
+  check-packages-and-shards:
+    name: Output Mutants
+    runs-on: ubuntu-latest
+    steps:
+      - name: Output Mutants
+        id: output_pr_mutants
+        uses: stacks-network/actions/mutation-testing/output-pr-mutants@main
+```

--- a/mutation-testing/output-pr-mutants/action.yml
+++ b/mutation-testing/output-pr-mutants/action.yml
@@ -5,7 +5,7 @@ runs:
 
   steps:
     - name: Download artifacts
-      uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff # v4.1.1
+      uses: actions/download-artifact@v3
 
     - name: Append output from shards
       shell: bash

--- a/mutation-testing/output-pr-mutants/action.yml
+++ b/mutation-testing/output-pr-mutants/action.yml
@@ -1,0 +1,153 @@
+name: Output Mutants
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v3
+
+    - name: Append output from shards
+      shell: bash
+      run: |
+        folders=("mutants-shard-big--1" "mutants-shard-big-0" "mutants-shard-big-1" "mutants-shard-big-2" "mutants-shard-big-3" "mutants-shard-big-4" "mutants-shard-big-5" "mutants-shard-big-6" "mutants-shard-big-7" "mutants-shard-small--1" "mutants-shard-small-0" "mutants-shard-small-1" "mutants-shard-small-2" "mutants-shard-small-3")
+        files=("missed.txt" "caught.txt" "timeout.txt" "unviable.txt")
+        mkdir -p mutants-shards
+
+        for file in "${files[@]}"; do
+          for folder in "${folders[@]}"; do
+            if [[ -s "$folder/$file" ]]; then
+              cat "$folder/$file" >> "mutants-shards/$file"
+            fi
+          done
+        done
+
+        for folder in "${folders[@]}"; do
+          if [[ -s "$folder/exit_code.txt" ]]; then
+            exit_code=$(<"${folder}/exit_code.txt")
+            most_relevant_exit_code=0
+
+            case $exit_code in
+            4)
+              most_relevant_exit_code=4
+              ;;
+            1)
+              [ "$most_relevant_exit_code" -eq 0 ] && most_relevant_exit_code=1
+              ;;
+            2)
+              [ "$most_relevant_exit_code" -eq 0 ] && most_relevant_exit_code=2
+              ;;
+            3)
+              [ "$most_relevant_exit_code" -eq 0 ] && most_relevant_exit_code=3
+              ;;
+            0)
+              ;;
+            *)
+              echo "Unknown exit code $exit_code"
+              most_relevant_exit_code=$exit_code
+              ;;
+            esac
+          fi
+        done
+
+        echo "$most_relevant_exit_code" > './mutants-shards/exit_code.txt'
+
+    - name: Print mutants
+      shell: bash
+      run: |
+        server_url="${{ github.server_url }}"
+        organisation="${{ github.repository_owner }}"
+        repository="${{ github.event.repository.name }}"
+        commit="${{ github.sha }}"
+
+        write_section() {
+          local section_title=$1
+          local file_name=$2
+
+          if [ -s "$file_name" ]; then
+            if [[ "$section_title" != "" ]]; then
+              echo "## $section_title" >> "$GITHUB_STEP_SUMMARY"
+            fi
+
+            if [[ "$section_title" == "Missed:" ]]; then
+              echo "<details>" >> "$GITHUB_STEP_SUMMARY"
+              echo "<summary>What are missed mutants?</summary>" >> "$GITHUB_STEP_SUMMARY"
+              echo "<br>" >> "$GITHUB_STEP_SUMMARY"
+              echo "No test failed with this mutation applied, which seems to indicate a gap in test coverage. Or, it may be that the mutant is undistinguishable from the correct code. You may wish to add a better test, or mark that the function should be skipped." >> "$GITHUB_STEP_SUMMARY"
+              echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+            elif [[ "$section_title" == "Timeout:" ]]; then
+              echo "<details>" >> "$GITHUB_STEP_SUMMARY"
+              echo "<summary>What are timeout mutants?</summary>" >> "$GITHUB_STEP_SUMMARY"
+              echo "<br>" >> "$GITHUB_STEP_SUMMARY"
+              echo "The mutation caused the test suite to run for a long time, until it was eventually killed. You might want to investigate the cause and potentially mark the function to be skipped." >> "$GITHUB_STEP_SUMMARY"
+              echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+            elif [[ "$section_title" == "Unviable:" ]]; then
+              echo "<details>" >> "$GITHUB_STEP_SUMMARY"
+              echo "<summary>What are unviable mutants?</summary>" >> "$GITHUB_STEP_SUMMARY"
+              echo "<br>" >> "$GITHUB_STEP_SUMMARY"
+              echo "The attempted mutation doesn't compile. This is inconclusive about test coverage and no action is needed, unless you wish to test the specific function, in which case you may wish to add a 'Default::default()' implementation for the specific return type." >> "$GITHUB_STEP_SUMMARY"
+              echo "</details>" >> "$GITHUB_STEP_SUMMARY"
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+            fi
+
+            if [[ "$section_title" != "" ]]; then
+              awk -F':' '{printf "- [ ] " "[" $0 "]"; file_path=$1; line=$2; $1=""; $2=""; printf "(" "'"$server_url"'/'"$organisation"'/'"$repository"'/blob/'"$commit"'/" file_path "#L" line-1 ")\n\n"}' "$file_name" >> "$GITHUB_STEP_SUMMARY"
+            else
+              awk -F':' '{printf "- [x] " "[" $0 "]"; file_path=$1; line=$2; $1=""; $2=""; printf "(" "'"$server_url"'/'"$organisation"'/'"$repository"'/blob/'"$commit"'/" file_path "#L" line-1 ")\n\n"}' "$file_name" >> "$GITHUB_STEP_SUMMARY"
+            fi
+
+            if [[ "$section_title" == "Missed:" ]]; then
+              echo "### To resolve this issue, consider one of the following options:" >> "$GITHUB_STEP_SUMMARY"
+              echo "- Modify or add tests including this function." >> "$GITHUB_STEP_SUMMARY"
+              echo "- If you are absolutely certain that this function should not undergo mutation testing, add '#[mutants::skip]' or '#[cfg_attr(test, mutants::skip)]' function header to skip it." >> "$GITHUB_STEP_SUMMARY"
+            elif [[ "$section_title" == "Timeout:" ]]; then
+              echo "### To resolve this issue, consider one of the following options:" >> "$GITHUB_STEP_SUMMARY"
+              echo "- Modify the tests that include this funcion." >> "$GITHUB_STEP_SUMMARY"
+              echo "- Add '#[mutants::skip]' or '#[cfg_attr(test, mutants::skip)]' function header to skip it." >> "$GITHUB_STEP_SUMMARY"
+            elif [[ "$section_title" == "Unviable:" ]]; then
+              echo "### To resolve this issue, consider one of the following options:" >> "$GITHUB_STEP_SUMMARY"
+              echo "- Create 'Default::default()' implementation for the specific structure." >> "$GITHUB_STEP_SUMMARY"
+              echo "- Add '#[mutants::skip]' or '#[cfg_attr(test, mutants::skip)]' function header to skip it." >> "$GITHUB_STEP_SUMMARY"
+            fi
+
+            echo >> "$GITHUB_STEP_SUMMARY"
+          fi
+        }
+
+        echo "# Uncaught Mutants" >> "$GITHUB_STEP_SUMMARY"
+        write_section "Missed:" "./mutants-shards/missed.txt"
+        write_section "Timeout:" "./mutants-shards/timeout.txt"
+        write_section "Unviable:" "./mutants-shards/unviable.txt"
+          
+        echo "# Caught Mutants" >> "$GITHUB_STEP_SUMMARY"
+        write_section "" "./mutants-shards/caught.txt"
+
+        exit_code=$(<"mutants-shards/exit_code.txt")
+
+        case $exit_code in
+          0)
+              if [[ -f ./mutants-shards/unviable.txt ]]; then
+                echo "Found unviable mutants!"
+                exit 1
+              fi
+            echo "All new and updated functions are caught!"
+            ;;
+          1)
+            echo "Invalid command line arguments!"
+            exit 1
+            ;;
+          2 | 3)
+            echo "Found missed/timeout/unviable mutants!"
+            exit 1
+            ;;
+          4)
+            echo "Building the packages failed without any mutations!"
+            exit 1
+            ;;
+          *)
+            echo "Unknown exit code: $exit_code"
+            exit 1
+          ;;
+        esac

--- a/mutation-testing/output-pr-mutants/action.yml
+++ b/mutation-testing/output-pr-mutants/action.yml
@@ -5,15 +5,17 @@ runs:
 
   steps:
     - name: Download artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@bb3fa7fd35ab8113a980912eb9f59b846d14e3ff # v4.1.1
 
     - name: Append output from shards
       shell: bash
       run: |
+        # List of all possible mutant outcomes file names and folder names collected from jobs.
         folders=("mutants-shard-big--1" "mutants-shard-big-0" "mutants-shard-big-1" "mutants-shard-big-2" "mutants-shard-big-3" "mutants-shard-big-4" "mutants-shard-big-5" "mutants-shard-big-6" "mutants-shard-big-7" "mutants-shard-small--1" "mutants-shard-small-0" "mutants-shard-small-1" "mutants-shard-small-2" "mutants-shard-small-3")
         files=("missed.txt" "caught.txt" "timeout.txt" "unviable.txt")
         mkdir -p mutants-shards
 
+        # If the folder/file path exists, append the output to it's corresponding file name in a newly created folder that will contain all outputs combined
         for file in "${files[@]}"; do
           for folder in "${folders[@]}"; do
             if [[ -s "$folder/$file" ]]; then
@@ -22,6 +24,12 @@ runs:
           done
         done
 
+        # If the folder/exit_code.txt path exists, check for the exit code and retain the most relevant one to a file
+        # - 4: unmutated build failed
+        # - 1: incorrect command line arguments
+        # - 2, 3: found timeout/missed/unviable mutants
+        # - 0: everything worked fine
+        # - *: unknown exit code
         for folder in "${folders[@]}"; do
           if [[ -s "$folder/exit_code.txt" ]]; then
             exit_code=$(<"${folder}/exit_code.txt")
@@ -55,11 +63,13 @@ runs:
     - name: Print mutants
       shell: bash
       run: |
+        # Info for creating the link that paths to the specific mutation tested
         server_url="${{ github.server_url }}"
         organisation="${{ github.repository_owner }}"
         repository="${{ github.event.repository.name }}"
         commit="${{ github.sha }}"
 
+        # Function to write to github step summary with specific info depending on the mutation category
         write_section() {
           local section_title=$1
           local file_name=$2
@@ -116,14 +126,17 @@ runs:
           fi
         }
 
+        # Print uncaught (missed/timeout/unviable) mutants to summary
         echo "# Uncaught Mutants" >> "$GITHUB_STEP_SUMMARY"
         write_section "Missed:" "./mutants-shards/missed.txt"
         write_section "Timeout:" "./mutants-shards/timeout.txt"
         write_section "Unviable:" "./mutants-shards/unviable.txt"
-          
+
+        # Print caught mutants to summary
         echo "# Caught Mutants" >> "$GITHUB_STEP_SUMMARY"
         write_section "" "./mutants-shards/caught.txt"
 
+        # Get most relevant exit code from the file and match it
         exit_code=$(<"mutants-shards/exit_code.txt")
 
         case $exit_code in

--- a/mutation-testing/pr-differences/action.yml
+++ b/mutation-testing/pr-differences/action.yml
@@ -79,7 +79,7 @@ runs:
         # Split the differences from git into 2 parts, big packages ('stacks-node' and 'stackslib') and small packages (all others) and put them into separate files
         while IFS= read -r line; do
           package=$(echo "$line" | cut -d'/' -f1)
-          ccase $package in
+          case $package in
             "testnet" | "stackslib")
               echo "$line" >> "mutants_by_packages/big_packages.txt"
               ;;

--- a/mutation-testing/pr-differences/action.yml
+++ b/mutation-testing/pr-differences/action.yml
@@ -21,7 +21,7 @@ runs:
     # Checkout the stacks-core code
     - name: Checkout the stacks core repo
       id: git_checkout_stacks_core
-      uses: actions/checkout@v3
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         fetch-depth: 0
 
@@ -33,7 +33,7 @@ runs:
     # Checkout the actions code
     - name: Get the action repo code
       id: git_checkout_actions
-      uses: actions/checkout@v3
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         repository: stacks-network/actions
         ref: feat/mutation-testing
@@ -42,11 +42,16 @@ runs:
     - name: Copy the git diff file to scripts folder
       shell: bash
       run: |
+        if [ ! -s git.diff ]; then
+          echo "Diff file missing!"
+        fi
+
         mv git.diff ./actions-repo/mutation-testing/shell-scripts/
 
-    - name: Install cargo mutants crate
-      shell: bash
-      run: cargo install --version 23.12.2 cargo-mutants
+    - uses: taiki-e/install-action@ac89944b5b150d78567ab6c02badfbe48b0b55aa # v2.20.16
+      name: Install cargo-mutants
+      with:
+        tool: cargo-mutants@23.12.2 # v23.12.2
 
     - name: Remove deleted file lines from git.diff file
       shell: bash
@@ -56,42 +61,64 @@ runs:
     - name: Split diffs into big and small packages and create regex patterns for them
       shell: bash
       run: |
+        # Check that the file exists before performing actions on it
+        if [ ! -s git.diff ]; then
+          echo "Diff file missing!"
+        fi
+
+        # Make a file containing all the mutants for the differences in the PR and a folder to split them into big and small packages
         cargo mutants --in-diff git.diff --list > all_mutants.txt
         mkdir -p mutants_by_packages
+
+        # Check that the file exists before performing actions on it
+        if [ ! -s all_mutants.txt ]; then
+          echo "The file containing mutants is missing or empty!"
+          exit 1
+        fi
 
         # Split the differences from git into 2 parts, big packages ('stacks-node' and 'stackslib') and small packages (all others) and put them into separate files
         while IFS= read -r line; do
           package=$(echo "$line" | cut -d'/' -f1)
-          if [[ $package == "testnet" || $package == "stackslib" ]]; then
-            echo "$line" >> "mutants_by_packages/big_packages.txt"
-          else
-            echo "$line" >> "mutants_by_packages/small_packages.txt"
-          fi
+          ccase $package in
+            "testnet" | "stackslib")
+              echo "$line" >> "mutants_by_packages/big_packages.txt"
+              ;;
+            *)
+              echo "$line" >> "mutants_by_packages/small_packages.txt"
+              ;;
+          esac
         done < all_mutants.txt
 
         # Create regex patterns of the mutants to be ran for `cargo mutants` -F flag and output them to files to be used later
         for package in mutants_by_packages/*; do
-          regex_pattern=""
+          if [ -s mutants_by_packages/$package ]; then
+            regex_pattern=""
 
-          while IFS= read -r line; do
-            escaped_line=$(echo "$line" | sed 's/[][()\.^$*+?{}|]/\\&/g')
-            regex_pattern+="($escaped_line)|"
-          done < "$package"
+            while IFS= read -r line; do
+              escaped_line=$(echo "$line" | sed 's/[][()\.^$*+?{}|]/\\&/g')
+              regex_pattern+="($escaped_line)|"
+            done < "$package"
 
-          regex_pattern="${regex_pattern%|}"
+            regex_pattern="${regex_pattern%|}"
 
-          if [[ "$package" == "mutants_by_packages/big_packages.txt" ]]; then
-            echo "$regex_pattern" > mutants_by_packages/regex_big.txt
-          else
-            echo "$regex_pattern" > mutants_by_packages/regex_small.txt
+            if [[ "$package" == "mutants_by_packages/big_packages.txt" ]]; then
+              echo "$regex_pattern" > mutants_by_packages/regex_big.txt
+            else
+              echo "$regex_pattern" > mutants_by_packages/regex_small.txt
+            fi
           fi
         done
+
+        exit 0
       working-directory: actions-repo/mutation-testing/shell-scripts
 
     - name: Run mutants and check the exit code of the command, fail the workflow if mutations are not caught
       shell: bash
       run: |
-        set +e  # Disable immediate exit on error
+        # Disable immediate exit on error
+        set +e
+
+        # Check which type of mutants to run: big, small, with or without shards, then capture the exit code
         if [[ ${{ inputs.shard }} == -1 ]]; then
           if [[ ${{ inputs.package-dimension }} == big ]]; then
             echo "Running mutants without shards on big packages"
@@ -113,10 +140,14 @@ runs:
             exit_code=$?
           fi
         fi
+
+        # Create the folder only containing the outcomes (.txt files) and make a file containing the exit code of the command
         mkdir mutants-shard-${{ inputs.package-dimension }}-${{ inputs.shard }}
         echo "$exit_code" > ./mutants-shard-${{ inputs.package-dimension }}-${{ inputs.shard }}/exit_code.txt
         mv ./mutants.out/*.txt mutants-shard-${{ inputs.package-dimension }}-${{ inputs.shard }}/
-        set -e  # Enable immediate exit on error again
+
+        # Enable immediate exit on error again
+        set -e
       working-directory: actions-repo/mutation-testing/shell-scripts
 
     - name: Upload artifact

--- a/mutation-testing/pr-differences/action.yml
+++ b/mutation-testing/pr-differences/action.yml
@@ -91,21 +91,19 @@ runs:
 
         # Create regex patterns of the mutants to be ran for `cargo mutants` -F flag and output them to files to be used later
         for package in mutants_by_packages/*; do
-          if [ -s mutants_by_packages/$package ]; then
-            regex_pattern=""
+          regex_pattern=""
 
-            while IFS= read -r line; do
-              escaped_line=$(echo "$line" | sed 's/[][()\.^$*+?{}|]/\\&/g')
-              regex_pattern+="($escaped_line)|"
-            done < "$package"
+          while IFS= read -r line; do
+            escaped_line=$(echo "$line" | sed 's/[][()\.^$*+?{}|]/\\&/g')
+            regex_pattern+="($escaped_line)|"
+          done < "$package"
 
-            regex_pattern="${regex_pattern%|}"
+          regex_pattern="${regex_pattern%|}"
 
-            if [[ "$package" == "mutants_by_packages/big_packages.txt" ]]; then
-              echo "$regex_pattern" > mutants_by_packages/regex_big.txt
-            else
-              echo "$regex_pattern" > mutants_by_packages/regex_small.txt
-            fi
+          if [[ "$package" == "mutants_by_packages/big_packages.txt" ]]; then
+            echo "$regex_pattern" > mutants_by_packages/regex_big.txt
+          else
+            echo "$regex_pattern" > mutants_by_packages/regex_small.txt
           fi
         done
 

--- a/mutation-testing/shell-scripts/remove-deleted-file-lines.sh
+++ b/mutation-testing/shell-scripts/remove-deleted-file-lines.sh
@@ -1,12 +1,27 @@
-#!/bin/bash
-
 input_file="git.diff"
 temp_file="temp_diff_file.diff"
 
+# Check if the commands exist on the host
+for cmd in tac awk sed; do
+  command -v "${cmd}" > /dev/null 2>&1 || { echo "Missing command: ${cmd}" && exit 1; }
+done
+
+# Check that the file exists before performing actions on it
+if [ ! -s "$input_file" ]; then
+  echo "Diff file missing!"
+  exit 1
+fi
+
 # Reverse the file, remove 4 lines after '+++ /dev/null', then reverse it back (editors can't go backwards - to remove lines above)
-tac "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
+tac "$input_file" > "$temp_file"
 sed '/+++ \/dev\/null/{n;N;N;N;d;}' "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
 tac "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
+
+# Check that the file exists before performing actions on it
+if [ ! -s "$temp_file" ]; then
+  echo "Diff file missing!"
+  exit 1
+fi
 
 # Remove the lines between '+++ /dev/null' (included) and 'diff --git a/'
 awk '
@@ -14,4 +29,14 @@ awk '
   /\+\+\+ \/dev\/null/ { in_block=1; next }
   in_block && /diff --git a\// { in_block=0; print; next }
   !in_block
-' "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
+' "$input_file" > "$temp_file"
+
+# Check that the file exists before performing actions on it
+if [ -s "$temp_file" ]; then
+  mv "$temp_file" "$input_file"
+else
+  echo "Temp diff file missing!"
+  exit 1
+fi
+
+exit 0

--- a/mutation-testing/shell-scripts/remove-deleted-file-lines.sh
+++ b/mutation-testing/shell-scripts/remove-deleted-file-lines.sh
@@ -17,12 +17,6 @@ tac "$input_file" > "$temp_file"
 sed '/+++ \/dev\/null/{n;N;N;N;d;}' "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
 tac "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
 
-# Check that the file exists before performing actions on it
-if [ ! -s "$temp_file" ]; then
-  echo "Diff file missing!"
-  exit 1
-fi
-
 # Remove the lines between '+++ /dev/null' (included) and 'diff --git a/'
 awk '
   BEGIN { in_block=0 }

--- a/mutation-testing/shell-scripts/remove-deleted-file-lines.sh
+++ b/mutation-testing/shell-scripts/remove-deleted-file-lines.sh
@@ -13,7 +13,7 @@ if [ ! -s "$input_file" ]; then
 fi
 
 # Reverse the file, remove 4 lines after '+++ /dev/null', then reverse it back (editors can't go backwards - to remove lines above)
-tac "$input_file" > "$temp_file"
+tac "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
 sed '/+++ \/dev\/null/{n;N;N;N;d;}' "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
 tac "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
 


### PR DESCRIPTION
@wileyj As you have previously suggested, I've moved everything that was possible from the main workflow of the `stacks-core` repository to composite actions in the `actions` repository, only keeping the calls to the composite in the main repo.
https://github.com/stacks-network/stacks-core/pull/4178#issuecomment-1883602391