### PR TITLE
Revert "Feature: enable monitoring_prom feature in CI actions"

### DIFF
--- a/stacks-core/cache/build-cache/action.yml
+++ b/stacks-core/cache/build-cache/action.yml
@@ -71,7 +71,6 @@ runs:
         cargo nextest archive \
           --build-jobs 8 \
           --workspace \
-          --features monitoring_prom \
           --tests \
           --locked \
           --archive-file ~/test_archive.tar.zst
@@ -89,7 +88,6 @@ runs:
         cd testnet/stacks-node && cargo nextest archive \
           --build-jobs 8 \
           --workspace \
-          --features monitoring_prom \
           --tests \
           --locked \
           --features prod-genesis-chainstate \

--- a/stacks-core/run-tests/action.yml
+++ b/stacks-core/run-tests/action.yml
@@ -40,7 +40,6 @@ runs:
           --verbose \
           --archive-file ${{ inputs.archive-file }} \
           --test-threads ${{ inputs.threads }} \
-          --features monitoring_prom \
           --retries ${{ inputs.retries }} \
           --run-ignored all \
           --fail-fast \

--- a/stacks-core/run-tests/partition/action.yml
+++ b/stacks-core/run-tests/partition/action.yml
@@ -44,7 +44,6 @@ runs:
           --retries ${{ inputs.retries }} \
           --final-status-level ${{ inputs.status-level }} \
           --fail-fast \
-          --features monitoring_prom \
           --success-output ${{ inputs.success-output }} \
           --status-level ${{ inputs.status-level }} \
           --archive-file ${{ inputs.archive-file }} \


### PR DESCRIPTION
Reverts stacks-network/actions#6

- cannot us `--features` with `--archive` when running tests. 
will create a new commit to add the features back to the archive file build step