### PR TITLE
fix: git diff

### DIFF
--- a/stacks-core/mutation-testing/check-packages-and-shards/action.yml
+++ b/stacks-core/mutation-testing/check-packages-and-shards/action.yml
@@ -38,7 +38,7 @@ runs:
       id: relative_diff
       shell: bash
       run: |
-        git diff origin/${{ github.base_ref }}.. > git.diff
+        git diff $(git merge-base origin/${{ github.base_ref }} HEAD)..HEAD > git.diff
 
     - name: Update git diff
       id: update_git_diff

--- a/stacks-core/mutation-testing/output-pr-mutants/action.yml
+++ b/stacks-core/mutation-testing/output-pr-mutants/action.yml
@@ -84,13 +84,7 @@ runs:
               most_relevant_exit_code=4
               ;;
             1)
-              [ "$most_relevant_exit_code" -eq 0 ] && most_relevant_exit_code=1
-              ;;
-            3)
-              [ "$most_relevant_exit_code" -eq 0 ] && most_relevant_exit_code=3
-              ;;
-            2)
-              [ "$most_relevant_exit_code" -eq 0 ] && most_relevant_exit_code=2
+              [ "$most_relevant_exit_code" -eq 0 ] || ( [ "$exit_code" -ne 0 ] && [ "$most_relevant_exit_code" -ne 4 ] && [ "$exit_code" -lt "$most_relevant_exit_code" ] ) && most_relevant_exit_code="$exit_code"
               ;;
             0)
               ;;

--- a/stacks-core/mutation-testing/pr-differences/action.yml
+++ b/stacks-core/mutation-testing/pr-differences/action.yml
@@ -33,7 +33,7 @@ runs:
       id: relative_diff
       shell: bash
       run: |
-        git diff origin/${{ github.base_ref }}.. > git.diff
+        git diff $(git merge-base origin/${{ github.base_ref }} HEAD)..HEAD > git.diff
 
     - uses: taiki-e/install-action@ac89944b5b150d78567ab6c02badfbe48b0b55aa # v2.20.16
       name: Install cargo-mutants


### PR DESCRIPTION
to replicate
```
git clone https://github.com/ASuciuX/stacks-core
cd stacks-core
git checkout 16b7bffd9f045ac56beade5b48eac1aba037b2e5
# previous implementation - doesn't work as expected
git diff 4b6638a73141f4ded6b8070c0f4f61d488130077 > git.diff
# current implementation - works as expected
git diff $(git merge-base 4b6638a73141f4ded6b8070c0f4f61d488130077 HEAD)..HEAD > git.diff
```