### PR TITLE
Mutants - Install nextest

### DIFF
--- a/stacks-core/mutation-testing/pr-differences/action.yml
+++ b/stacks-core/mutation-testing/pr-differences/action.yml
@@ -41,6 +41,12 @@ runs:
       with:
         tool: cargo-mutants@24.1.1 # v24.1.1
 
+    - uses: baptiste0928/cargo-install@1cd874a5478fdca35d868ccc74640c5aabbb8f1b # v3.0.0
+      name: Install cargo-nextest
+      with:
+        crate: cargo-nextest
+        locked: true
+
     - name: Update git diff
       id: update_git_diff
       shell: bash

--- a/stacks-core/mutation-testing/pr-differences/action.yml
+++ b/stacks-core/mutation-testing/pr-differences/action.yml
@@ -41,11 +41,11 @@ runs:
       with:
         tool: cargo-mutants@24.1.1 # v24.1.1
 
-    - uses: baptiste0928/cargo-install@1cd874a5478fdca35d868ccc74640c5aabbb8f1b # v3.0.0
+    - uses: taiki-e/install-action@ac89944b5b150d78567ab6c02badfbe48b0b55aa # v2.20.16
       name: Install cargo-nextest
+      id: install_cargo_nextest
       with:
-        crate: cargo-nextest
-        locked: true
+        tool: nextest # Latest version
 
     - name: Update git diff
       id: update_git_diff


### PR DESCRIPTION
Add a step to install the `cargo-nextest` crate in the `pr-differences` action file.
Failed workflow: https://github.com/ASuciuX/stacks-core/actions/runs/7579856843/attempts/2?pr=51
Running workflow (failed due to missed mutants): https://github.com/ASuciuX/stacks-core/actions/runs/7579856843?pr=51