### PR TITLE
Mutants Optimisations: big-packages, timeout multiplier, stacks-signer case

### DIFF
--- a/stacks-core/mutation-testing/check-packages-and-shards/README.md
+++ b/stacks-core/mutation-testing/check-packages-and-shards/README.md
@@ -1,16 +1,19 @@
 # Check Packages and Shards action
 
-Checks whether to run mutants on big ([stackslib](https://github.com/stacks-network/stacks-core/tree/develop/stackslib)/[stacks-node](https://github.com/stacks-network/stacks-core/tree/develop/testnet/stacks-node)) or small packages (all others), and whether to run them using strategy matrix or not.
+Checks whether to run mutants on [stackslib](https://github.com/stacks-network/stacks-core/tree/develop/stackslib), [stacks-node](https://github.com/stacks-network/stacks-core/tree/develop/testnet/stacks-node), [stacks-signer](https://github.com/stacks-network/stacks-core/tree/develop/stacks-signer), or small packages (all others), and whether to run them using strategy matrix or not.
 
 ## Documentation
 
 ### Outputs
 | Output | Description |
 | ------------------------------- | ----------------------------------------------------- |
-| `run_big_packages` | True if there are mutants on `stackslib` or `stacks-node` packages, false otherwise.
-| `big_packages_with_shards` | True if there are more than 15 mutants on big packages.
+| `run_stackslib` | True if there are mutants on `stackslib` package, false otherwise.
+| `stackslib_with_shards` | True if there are more than 7 mutants on `stackslib` package.
+| `run_stacks_node` | True if there are mutants on `stacks-node` package, false otherwise.
+| `stacks_node_with_shards` | True if there are more than 19 mutants on `stacks-node` package.
 | `run_small_packages` | True if there are mutants on small packages, false otherwise.
-| `small_packages_with_shards` | True if there are more than 79 (119 if `big_packages_with_shards` is true) mutants on small packages.
+| `small_packages_with_shards` | True if there are more than 79 mutants on small packages.
+| `run_stacks_signer` | True if there are mutants on `stacks-signer` package.
 
 ## Usage
 

--- a/stacks-core/mutation-testing/check-packages-and-shards/action.yml
+++ b/stacks-core/mutation-testing/check-packages-and-shards/action.yml
@@ -172,6 +172,8 @@ runs:
         # If stacks_signer file exists and is not empty, run mutants on stacks-signer package
         if [[ -s mutants_by_packages/stacks-signer.txt ]]; then
           echo "run_stacks_signer=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "run_stacks_signer=false" >> "$GITHUB_OUTPUT"
         fi
 
         # If there are mutants from stackslib package, check whether to run or not and with or without shards
@@ -182,6 +184,9 @@ runs:
           else
             echo "stackslib_with_shards=false" >> "$GITHUB_OUTPUT"
           fi
+        else
+          echo "run_stackslib=false" >> "$GITHUB_OUTPUT"
+          echo "stackslib_with_shards=false" >> "$GITHUB_OUTPUT"
         fi
 
         # If there are mutants from stacks-node package, check whether to run or not and with or without shards
@@ -192,6 +197,9 @@ runs:
           else
             echo "stacks_node_with_shards=false" >> "$GITHUB_OUTPUT"
           fi
+        else
+          echo "run_stacks_node=false" >> "$GITHUB_OUTPUT"
+          echo "stacks_node_with_shards=false" >> "$GITHUB_OUTPUT"
         fi
 
         # If there are mutants from small packages, check whether to run or not and with or without shards
@@ -202,6 +210,9 @@ runs:
           else
             echo "small_packages_with_shards=false" >> "$GITHUB_OUTPUT"
           fi
+        else
+          echo "run_small_packages=false" >> "$GITHUB_OUTPUT"
+          echo "small_packages_with_shards=false" >> "$GITHUB_OUTPUT"
         fi
 
         exit 0

--- a/stacks-core/mutation-testing/check-packages-and-shards/action.yml
+++ b/stacks-core/mutation-testing/check-packages-and-shards/action.yml
@@ -179,6 +179,8 @@ runs:
           echo "run_stackslib=true" >> "$GITHUB_OUTPUT"
           if [[ $number_of_stackslib_mutants -gt 7 ]]; then
             echo "stackslib_with_shards=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "stackslib_with_shards=false" >> "$GITHUB_OUTPUT"
           fi
         fi
 
@@ -187,6 +189,8 @@ runs:
           echo "run_stacks_node=true" >> "$GITHUB_OUTPUT"
           if [[ $number_of_stacks_node_mutants -gt 19 ]]; then
             echo "stacks_node_with_shards=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "stacks_node_with_shards=false" >> "$GITHUB_OUTPUT"
           fi
         fi
 
@@ -195,6 +199,8 @@ runs:
           echo "run_small_packages=true" >> "$GITHUB_OUTPUT"
           if [[ $number_of_small_mutants -gt 79 ]]; then
             echo "small_packages_with_shards=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "small_packages_with_shards=false" >> "$GITHUB_OUTPUT"
           fi
         fi
 

--- a/stacks-core/mutation-testing/check-packages-and-shards/action.yml
+++ b/stacks-core/mutation-testing/check-packages-and-shards/action.yml
@@ -6,17 +6,20 @@ branding:
 
 outputs:
   run_big_packages:
-    description: "True if there are packages on `stackslib` or `stacks-node`."
+    description: "True if there are mutants on `stackslib` or `stacks-node`."
     value: ${{ steps.check_packages_and_shards.outputs.run_big_packages }}
   big_packages_with_shards:
     description: "True if there are more than 16 mutants on `stackslib` and `stacks-node`."
     value: ${{ steps.check_packages_and_shards.outputs.big_packages_with_shards }}
   run_small_packages:
-    description: "True if there are packages on other packages than `stackslib` or `stacks-node`."
+    description: "True if there are mutants on other packages than `stackslib` or `stacks-node`."
     value: ${{ steps.check_packages_and_shards.outputs.run_small_packages }}
   small_packages_with_shards:
     description: "True if there are more than 79 (119 if `big_packages_with_shards` is true) mutants on small packages."
     value: ${{ steps.check_packages_and_shards.outputs.small_packages_with_shards }}
+  run_stacks_signer:
+    description: "True if there are mutants on `stacks-signer` package."
+    value: ${{ steps.check_packages_and_shards.outputs.run_stacks_signer }}
 
 runs:
   using: "composite"
@@ -122,6 +125,9 @@ runs:
             "testnet" | "stackslib")
               echo "$line" >> "mutants_by_packages/big_packages.txt"
               ;;
+            "stacks-signer")
+              echo "$line" >> "mutants_by_packages/stacks_signer.txt"
+              ;;
             *)
               echo "$line" >> "mutants_by_packages/small_packages.txt"
               ;;
@@ -145,6 +151,13 @@ runs:
         # If small_packages file exists, count how many mutants there are
         if [[ -s mutants_by_packages/small_packages.txt ]]; then
           number_of_small_mutants=$(cat mutants_by_packages/small_packages.txt | awk 'END { print NR }' | tr -d '[:space:]')
+        fi
+
+        # If stacks_signer file exists and is not empty, run mutants on stacks-signer package
+        if [[ -s mutants_by_packages/stacks_signer.txt ]]; then
+          echo "run_stacks_signer=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "run_stacks_signer=false" >> "$GITHUB_OUTPUT"
         fi
 
         # Set the mutants limit for when to run with shards on the small packages

--- a/stacks-core/mutation-testing/check-packages-and-shards/action.yml
+++ b/stacks-core/mutation-testing/check-packages-and-shards/action.yml
@@ -170,7 +170,7 @@ runs:
         fi
 
         # If stacks_signer file exists and is not empty, run mutants on stacks-signer package
-        if [[ -s mutants_by_packages/stacks_signer.txt ]]; then
+        if [[ -s mutants_by_packages/stacks-signer.txt ]]; then
           echo "run_stacks_signer=true" >> "$GITHUB_OUTPUT"
         fi
 

--- a/stacks-core/mutation-testing/check-packages-and-shards/action.yml
+++ b/stacks-core/mutation-testing/check-packages-and-shards/action.yml
@@ -38,6 +38,7 @@ runs:
         fetch-depth: 0
 
     - name: Install cargo-mutants
+      shell: bash
       id: install_cargo_mutants
       run: |
         cargo install --git https://github.com/ASuciuX/cargo-mutants --branch feat/variable-test-timeout cargo-mutants # v24.2.0 - with test timeout multiplier implementation

--- a/stacks-core/mutation-testing/check-packages-and-shards/action.yml
+++ b/stacks-core/mutation-testing/check-packages-and-shards/action.yml
@@ -5,17 +5,23 @@ branding:
   color: "gray-dark"
 
 outputs:
-  run_big_packages:
-    description: "True if there are mutants on `stackslib` or `stacks-node`."
-    value: ${{ steps.check_packages_and_shards.outputs.run_big_packages }}
-  big_packages_with_shards:
-    description: "True if there are more than 16 mutants on `stackslib` and `stacks-node`."
-    value: ${{ steps.check_packages_and_shards.outputs.big_packages_with_shards }}
+  run_stackslib:
+    description: "True if there are mutants on `stackslib` package."
+    value: ${{ steps.check_packages_and_shards.outputs.run_stackslib }}
+  stackslib_with_shards:
+    description: "True if there are more than 7 mutants on `stackslib`."
+    value: ${{ steps.check_packages_and_shards.outputs.stackslib_with_shards }}
+  run_stacks_node:
+    description: "True if there are mutants on `stacks-node` package."
+    value: ${{ steps.check_packages_and_shards.outputs.run_stacks_node }}
+  stacks_node_with_shards:
+    description: "True if there are more than 19 mutants on `stacks-node`."
+    value: ${{ steps.check_packages_and_shards.outputs.stacks_node_with_shards }}
   run_small_packages:
-    description: "True if there are mutants on other packages than `stackslib` or `stacks-node`."
+    description: "True if there are mutants on other packages than `stackslib`, `stacks-node` or `stacks-signer`."
     value: ${{ steps.check_packages_and_shards.outputs.run_small_packages }}
   small_packages_with_shards:
-    description: "True if there are more than 79 (119 if `big_packages_with_shards` is true) mutants on small packages."
+    description: "True if there are more than 79 mutants on small packages."
     value: ${{ steps.check_packages_and_shards.outputs.small_packages_with_shards }}
   run_stacks_signer:
     description: "True if there are mutants on `stacks-signer` package."
@@ -31,11 +37,10 @@ runs:
       with:
         fetch-depth: 0
 
-    - uses: taiki-e/install-action@ac89944b5b150d78567ab6c02badfbe48b0b55aa # v2.20.16
+    - name: Install cargo-mutants
       id: install_cargo_mutants
-      name: Install cargo-mutants
-      with:
-        tool: cargo-mutants@24.1.1 # v24.1.1
+      run: |
+        cargo install --git https://github.com/ASuciuX/cargo-mutants --branch feat/variable-test-timeout cargo-mutants # v24.2.0 - with test timeout multiplier implementation
 
     - name: Relative diff
       id: relative_diff
@@ -118,18 +123,22 @@ runs:
           exit 1
         fi
 
-        # Split the differences from git into 2 parts, big packages ('stacks-node' and 'stackslib') and small packages (all others) and put them into separate files
+        # Split the differences from git into packages: 'stackslib', 'stacks-node', 'stacks-signer' and small packages (all others) and put them into separate files
         while IFS= read -r line; do
           package=$(echo "$line" | cut -d'/' -f1)
+
           case $package in
-            "testnet" | "stackslib")
-              echo "$line" >> "mutants_by_packages/big_packages.txt"
+            "stackslib")
+              echo "$line" >> "mutants_by_packages/stackslib.txt"
+              ;;
+            "testnet")
+              echo "$line" >> "mutants_by_packages/stacks-node.txt"
               ;;
             "stacks-signer")
-              echo "$line" >> "mutants_by_packages/stacks_signer.txt"
+              echo "$line" >> "mutants_by_packages/stacks-signer.txt"
               ;;
             *)
-              echo "$line" >> "mutants_by_packages/small_packages.txt"
+              echo "$line" >> "mutants_by_packages/small-packages.txt"
               ;;
           esac
         done < all_mutants.txt
@@ -140,52 +149,52 @@ runs:
       id: check_packages_and_shards
       shell: bash
       run: |
-        number_of_big_mutants=0
+        number_of_stackslib_mutants=0
+        number_of_stacks_node_mutants=0
         number_of_small_mutants=0
 
-        # If big_packages file exists, count how many mutants there are
-        if [[ -s mutants_by_packages/big_packages.txt ]]; then
-          number_of_big_mutants=$(cat mutants_by_packages/big_packages.txt | awk 'END { print NR }' | tr -d '[:space:]')
+        # If stackslib.txt file exists, count how many mutants there are
+        if [[ -s mutants_by_packages/stackslib.txt ]]; then
+          number_of_stackslib_mutants=$(cat mutants_by_packages/stackslib.txt | awk 'END { print NR }' | tr -d '[:space:]')
         fi
 
-        # If small_packages file exists, count how many mutants there are
-        if [[ -s mutants_by_packages/small_packages.txt ]]; then
-          number_of_small_mutants=$(cat mutants_by_packages/small_packages.txt | awk 'END { print NR }' | tr -d '[:space:]')
+        # If stacks-node.txt file exists, count how many mutants there are
+        if [[ -s mutants_by_packages/stacks-node.txt ]]; then
+          number_of_stacks_node_mutants=$(cat mutants_by_packages/stacks-node.txt | awk 'END { print NR }' | tr -d '[:space:]')
+        fi
+
+        # If small-packages.txt file exists, count how many mutants there are
+        if [[ -s mutants_by_packages/small-packages.txt ]]; then
+          number_of_small_mutants=$(cat mutants_by_packages/small-packages.txt | awk 'END { print NR }' | tr -d '[:space:]')
         fi
 
         # If stacks_signer file exists and is not empty, run mutants on stacks-signer package
         if [[ -s mutants_by_packages/stacks_signer.txt ]]; then
           echo "run_stacks_signer=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "run_stacks_signer=false" >> "$GITHUB_OUTPUT"
         fi
 
-        # Set the mutants limit for when to run with shards on the small packages
-        # If there are mutants from big packages, check whether to run with or without shards, otherwise there's nothing to run
-        if [[ $number_of_big_mutants -gt 15 ]]; then
-          small_packages_shard_limit=119
-          echo "run_big_packages=true" >> "$GITHUB_OUTPUT"
-          echo "big_packages_with_shards=true" >> "$GITHUB_OUTPUT"
-        else
-          small_packages_shard_limit=79
-          if [[ $number_of_big_mutants -ne 0 ]]; then
-            echo "run_big_packages=true" >> "$GITHUB_OUTPUT"
-            echo "big_packages_with_shards=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "run_big_packages=false" >> "$GITHUB_OUTPUT"
+        # If there are mutants from stackslib package, check whether to run or not and with or without shards
+        if [[ $number_of_stackslib_mutants -ne 0 ]]; then
+          echo "run_stackslib=true" >> "$GITHUB_OUTPUT"
+          if [[ $number_of_stackslib_mutants -gt 7 ]]; then
+            echo "stackslib_with_shards=true" >> "$GITHUB_OUTPUT"
           fi
         fi
 
-        # If there are mutants from small packages, check whether to run with or without shards, otherwise there's nothing to run
+        # If there are mutants from stacks-node package, check whether to run or not and with or without shards
+        if [[ $number_of_stacks_node_mutants -ne 0 ]]; then
+          echo "run_stacks_node=true" >> "$GITHUB_OUTPUT"
+          if [[ $number_of_stacks_node_mutants -gt 19 ]]; then
+            echo "stacks_node_with_shards=true" >> "$GITHUB_OUTPUT"
+          fi
+        fi
+
+        # If there are mutants from small packages, check whether to run or not and with or without shards
         if [[ $number_of_small_mutants -ne 0 ]]; then
           echo "run_small_packages=true" >> "$GITHUB_OUTPUT"
-          if [[ $number_of_small_mutants -gt $small_packages_shard_limit ]]; then
+          if [[ $number_of_small_mutants -gt 79 ]]; then
             echo "small_packages_with_shards=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "small_packages_with_shards=false" >> "$GITHUB_OUTPUT"
           fi
-        else
-          echo "run_small_packages=false" >> "$GITHUB_OUTPUT"
         fi
 
         exit 0

--- a/stacks-core/mutation-testing/output-pr-mutants/README.md
+++ b/stacks-core/mutation-testing/output-pr-mutants/README.md
@@ -8,10 +8,13 @@ Write the mutants tested in the previous jobs of the same workflow to github ste
 
 | Input | Description | Required | Default |
 | ------------------------------- | ----------------------------------------------------- | ------------------------- | ------------------------- |
-| `big_packages` | True if there were big packages running | true |  |
-| `shards_for_big_packages` | True if the big packages were running using matrix | true |  |
-| `small_packages` | True if there were small packages running | true |  |
-| `shards_for_small_packages` | True if the small packages were running using matrix | true |  |
+| `stackslib_package` | True if there were mutants running on stackslib package | true |  |
+| `shards_for_stackslib_package` | True if mutants on stackslib were running using matrix | true |  |
+| `stacks_node_package` | True if there were mutants running on stacks-node package | true |  |
+| `shards_for_stacks_node_package` | True if mutants on stacks-node were running using matrix | true |  |
+| `small_packages` | True if there were mutants running on small packages | true |  |
+| `shards_for_small_packages` | True if mutants on small packages were running using matrix | true |  |
+| `stacks_signer` | True if there were mutants running on stacks-signer package | true |  |
 
 ## Usage
 
@@ -27,8 +30,11 @@ jobs:
         id: output_pr_mutants
         uses: stacks-network/actions/stacks-core/mutation-testing/output-pr-mutants@main
         with:
-          big_packages: "true"
-          shards_for_big_packages: "false"
-          small_packages: "true"
-          shards_for_small_packages: "true"
+          stackslib_package: "true"
+          shards_for_stackslib_package: "false"
+          stacks_node_package: "true"
+          shards_for_stacks_node_package: "true"
+          small_packages: "false"
+          shards_for_small_packages: "false"
+          stacks_signer: "true"
 ```

--- a/stacks-core/mutation-testing/output-pr-mutants/action.yml
+++ b/stacks-core/mutation-testing/output-pr-mutants/action.yml
@@ -17,6 +17,9 @@ inputs:
   shards_for_small_packages:
     description: "True if the small packages were running using matrix."
     required: true
+  stacks_signer:
+    description: "True if there were mutants on `stacks-signer` package."
+    required: true
 
 runs:
   using: "composite"
@@ -50,6 +53,11 @@ runs:
           else
             folders+=("mutants-shard-small--1")
           fi
+        fi
+
+        # Check and append the folder that should be uploaded to artifacts for the `stacks-signer` package
+        if ${{ inputs.stacks_signer }} == "true"; then
+          folders+=("mutants-shard-stacks-signer--1")
         fi
 
         files=("missed.txt" "caught.txt" "timeout.txt" "unviable.txt")

--- a/stacks-core/mutation-testing/output-pr-mutants/action.yml
+++ b/stacks-core/mutation-testing/output-pr-mutants/action.yml
@@ -5,20 +5,26 @@ branding:
   color: "gray-dark"
 
 inputs:
-  big_packages:
-    description: "True if there were big packages running."
+  stackslib_package:
+    description: "True if there were mutants running on stackslib package."
     required: true
-  shards_for_big_packages:
-    description: "True if the big packages were running using matrix."
+  shards_for_stackslib_package:
+    description: "True if mutants on stackslib were running using matrix."
+    required: true
+  stacks_node_package:
+    description: "True if there were mutants running on stacks-node package."
+    required: true
+  shards_for_stacks_node_package:
+    description: "True if mutants on stacks-node were running using matrix."
     required: true
   small_packages:
-    description: "True if there were small packages running."
+    description: "True if there were mutants running on small packages."
     required: true
   shards_for_small_packages:
-    description: "True if the small packages were running using matrix."
+    description: "True if mutants on small packages were running using matrix."
     required: true
   stacks_signer:
-    description: "True if there were mutants on `stacks-signer` package."
+    description: "True if there were mutants running on stacks-signer package."
     required: true
 
 runs:
@@ -33,14 +39,25 @@ runs:
       id: append_mutant_outcomes
       shell: bash
       run: |
-        # Check and append the folders that should be uploaded to artifacts for the big packages
-        if ${{ inputs.big_packages }} == "true"; then
-          if ${{ inputs.shards_for_big_packages }} == "true"; then
+        # Check and append the folders that should be uploaded to artifacts for the stackslib package
+        if ${{ inputs.stackslib_package }} == "true"; then
+          if ${{ inputs.shards_for_stackslib_package }} == "true"; then
             for i in {0..7}; do
-              folders+=("mutants-shard-big-$i")
+              folders+=("mutants-shard-stackslib-$i")
             done
           else
-            folders+=("mutants-shard-big--1")
+            folders+=("mutants-shard-stackslib--1")
+          fi
+        fi
+
+        # Check and append the folders that should be uploaded to artifacts for the stacks-node package
+        if ${{ inputs.stacks_node_package }} == "true"; then
+          if ${{ inputs.shards_for_stacks_node_package }} == "true"; then
+            for i in {0..3}; do
+              folders+=("mutants-shard-stacks-node-$i")
+            done
+          else
+            folders+=("mutants-shard-stacks-node--1")
           fi
         fi
 
@@ -55,7 +72,7 @@ runs:
           fi
         fi
 
-        # Check and append the folder that should be uploaded to artifacts for the `stacks-signer` package
+        # Check and append the folder that should be uploaded to artifacts for the stacks-signer package
         if ${{ inputs.stacks_signer }} == "true"; then
           folders+=("mutants-shard-stacks-signer--1")
         fi

--- a/stacks-core/mutation-testing/pr-differences/README.md
+++ b/stacks-core/mutation-testing/pr-differences/README.md
@@ -9,7 +9,7 @@ Run mutants for differences in pull requests, and upload the mutant outcomes and
 | Input | Description | Required | Default |
 | ------------------------------- | ----------------------------------------------------- | ------------------------- | ------------------------- |
 | `shard` | The number of the shard to run (`-1` if ran without shards) | false | -1 |
-| `package-dimension` | The dimension of the package. `big` for [stacks-node](https://github.com/stacks-network/stacks-core/tree/develop/testnet/stacks-node) and [stackslib](https://github.com/stacks-network/stacks-core/tree/develop/stackslib), `small` for others | true |  |
+| `package` | The package to run mutants on. [Stackslib](https://github.com/stacks-network/stacks-core/tree/develop/stackslib), [stacks-node](https://github.com/stacks-network/stacks-core/tree/develop/testnet/stacks-node) and [stacks-signer](https://github.com/stacks-network/stacks-core/tree/develop/stacks-signer) are independent, all others are run as `small`. | true |  |
 
 ## Usage
 
@@ -25,5 +25,5 @@ jobs:
         id: pr-differences-mutants
         uses: stacks-network/actions/stacks-core/mutation-testing/pr-differences@main
         with:
-          package-dimension: "big"
+          package-dimension: "small"
 ```

--- a/stacks-core/mutation-testing/pr-differences/action.yml
+++ b/stacks-core/mutation-testing/pr-differences/action.yml
@@ -37,6 +37,7 @@ runs:
 
     - name: Install cargo-mutants
       id: install_cargo_mutants
+      shell: bash
       run: |
         cargo install --git https://github.com/ASuciuX/cargo-mutants --branch feat/variable-test-timeout cargo-mutants # v24.2.0 - with test timeout multiplier implementation
 

--- a/stacks-core/mutation-testing/pr-differences/action.yml
+++ b/stacks-core/mutation-testing/pr-differences/action.yml
@@ -198,6 +198,9 @@ runs:
             fi
           elif [[ ${{ inputs.package }} == stacks-signer ]]; then
             if [[ -f mutants_by_packages/regex-stacks-signer.txt ]]; then
+              # Run an initial cargo nextest
+              cargo nextest run -p stacks-signer --test-threads 1
+
               echo "Running mutants without shards on stacks-signer package"
               cargo mutants --timeout-multiplier 1.5 --no-shuffle -vV -F "$(<mutants_by_packages/regex-stacks-signer.txt)" -E ": replace .{1,2} with .{1,2} in " --output ./ --test-tool=nextest -- --all-targets --test-threads 1
               exit_code=$?

--- a/stacks-core/mutation-testing/pr-differences/action.yml
+++ b/stacks-core/mutation-testing/pr-differences/action.yml
@@ -9,8 +9,8 @@ inputs:
     description: "The number of the shard to run (`-1` if ran without shards)"
     required: false
     default: -1
-  package-dimension:
-    description: "The dimension of the package. `big` for `stacks-node` and `stackslib`, `small` for others, `stacks-signer` for `stacks-signer`."
+  package:
+    description: "The package to run mutants on. `stackslib`, `stacks-node` and `stacks-signer` are independent, all others are run as `small`."
     required: true
 
 runs:
@@ -35,11 +35,10 @@ runs:
       run: |
         git diff $(git merge-base origin/${{ github.base_ref }} HEAD)..HEAD > git.diff
 
-    - uses: taiki-e/install-action@ac89944b5b150d78567ab6c02badfbe48b0b55aa # v2.20.16
-      name: Install cargo-mutants
+    - name: Install cargo-mutants
       id: install_cargo_mutants
-      with:
-        tool: cargo-mutants@24.1.1 # v24.1.1
+      run: |
+        cargo install --git https://github.com/ASuciuX/cargo-mutants --branch feat/variable-test-timeout cargo-mutants # v24.2.0 - with test timeout multiplier implementation
 
     - uses: taiki-e/install-action@ac89944b5b150d78567ab6c02badfbe48b0b55aa # v2.20.16
       name: Install cargo-nextest
@@ -122,19 +121,22 @@ runs:
           exit 1
         fi
 
-        # Split the differences from git into 2 parts, big packages ('stacks-node' and 'stackslib') and small packages (all others) and put them into separate files
+        # Split the differences from git into packages: 'stackslib', 'stacks-node', 'stacks-signer' and small packages (all others) and put them into separate files
         while IFS= read -r line; do
           package=$(echo "$line" | cut -d'/' -f1)
 
           case $package in
-            "testnet" | "stackslib")
-              echo "$line" >> "mutants_by_packages/big_packages.txt"
+            "stackslib")
+              echo "$line" >> "mutants_by_packages/stackslib.txt"
+              ;;
+            "testnet")
+              echo "$line" >> "mutants_by_packages/stacks-node.txt"
               ;;
             "stacks-signer")
-              echo "$line" >> "mutants_by_packages/stacks_signer.txt"
+              echo "$line" >> "mutants_by_packages/stacks-signer.txt"
               ;;
             *)
-              echo "$line" >> "mutants_by_packages/small_packages.txt"
+              echo "$line" >> "mutants_by_packages/small-packages.txt"
               ;;
           esac
         done < all_mutants.txt
@@ -150,13 +152,20 @@ runs:
 
           regex_pattern="${regex_pattern%|}"
 
-          if [[ "$package" == "mutants_by_packages/big_packages.txt" ]]; then
-            echo "$regex_pattern" > mutants_by_packages/regex_big.txt
-          elif [[ "$package" == "mutants_by_packages/stacks_signer.txt" ]]; then
-            echo "$regex_pattern" > mutants_by_packages/regex_stacks_signer.txt
-          else
-            echo "$regex_pattern" > mutants_by_packages/regex_small.txt
-          fi
+          case $package in
+            "mutants_by_packages/stackslib.txt")
+              echo "$regex_pattern" > mutants_by_packages/regex-stackslib.txt
+              ;;
+            "mutants_by_packages/stacks-node.txt")
+              echo "$regex_pattern" > mutants_by_packages/regex-stacks-node.txt
+              ;;
+            "mutants_by_packages/stacks-signer.txt")
+              echo "$regex_pattern" > mutants_by_packages/regex-stacks-signer.txt
+              ;;
+            *)
+              echo "$regex_pattern" > mutants_by_packages/regex-small-packages.txt
+              ;;
+          esac
         done
 
         exit 0
@@ -170,44 +179,66 @@ runs:
 
         # Check which type of mutants to run: big, small, with or without shards, then capture the exit code
         if [[ ${{ inputs.shard }} == -1 ]]; then
-          if [[ ${{ inputs.package-dimension }} == big ]]; then
-            if [[ -f mutants_by_packages/regex_big.txt ]]; then
-              echo "Running mutants without shards on big packages"
-              cargo mutants --no-shuffle -vV -F "$(<mutants_by_packages/regex_big.txt)" -E ": replace .{1,2} with .{1,2} in " --output ./ --test-tool=nextest -- --all-targets --test-threads 1
+          if [[ ${{ inputs.package }} == stackslib ]]; then
+            if [[ -f mutants_by_packages/regex-stackslib.txt ]]; then
+              echo "Running mutants without shards on stackslib package"
+              cargo mutants --timeout-multiplier 1.5 --no-shuffle -vV -F "$(<mutants_by_packages/regex-stackslib.txt)" -E ": replace .{1,2} with .{1,2} in " --output ./ --test-tool=nextest -- --all-targets --test-threads 1
               exit_code=$?
             else
               echo "File containing mutants doesn't exist!"
             fi
-          elif [[ ${{ inputs.package-dimension }} == stacks-signer ]]; then
-            if [[ -f mutants_by_packages/regex_stacks_signer.txt ]]; then
-              echo "Found mutants on stacks-signer package, running them"
-              cargo mutants --no-shuffle -vV -F "$(<mutants_by_packages/regex_stacks_signer.txt)" -E ": replace .{1,2} with .{1,2} in " --output ./ --test-tool=nextest -- --all-targets --test-threads 1
+          elif [[ ${{ inputs.package }} == stacks-node ]]; then
+            if [[ -f mutants_by_packages/regex-stacks-node.txt ]]; then
+              echo "Running mutants without shards on stacks-node package"
+              cargo mutants --timeout-multiplier 1.5 --no-shuffle -vV -F "$(<mutants_by_packages/regex-stacks-node.txt)" -E ": replace .{1,2} with .{1,2} in " --output ./ --test-tool=nextest -- --all-targets --test-threads 1
+              exit_code=$?
+            else
+              echo "File containing mutants doesn't exist!"
+            fi
+          elif [[ ${{ inputs.package }} == stacks-signer ]]; then
+            if [[ -f mutants_by_packages/regex-stacks-signer.txt ]]; then
+              # Run a basic cargo build (for debugging)
+              cargo build
+
+              # Run a basic cargo nextest (for debugging)
+              cargo nextest run -p stacks-signer --test-threads 1
+
+              echo "Running mutants without shards on stacks-signer package"
+              cargo mutants --timeout-multiplier 1.5 --no-shuffle -vV -F "$(<mutants_by_packages/regex-stacks-signer.txt)" -E ": replace .{1,2} with .{1,2} in " --output ./ --test-tool=nextest -- --all-targets --test-threads 1
               exit_code=$?
             else
               echo "File containing mutants doesn't exist!"
             fi
           else
-            if [[ -f mutants_by_packages/regex_small.txt ]]; then
+            if [[ -f mutants_by_packages/regex-small-packages.txt ]]; then
               echo "Running mutants without shards on small packages"
-              cargo mutants --no-shuffle -vV -F "$(<mutants_by_packages/regex_small.txt)" -E ": replace .{1,2} with .{1,2} in " --output ./ --test-tool=nextest -- --all-targets
+              cargo mutants --timeout-multiplier 1.5 --no-shuffle -vV -F "$(<mutants_by_packages/regex-small-packages.txt)" -E ": replace .{1,2} with .{1,2} in " --output ./ --test-tool=nextest -- --all-targets
               exit_code=$?
             else
               echo "File containing mutants doesn't exist!"
             fi
           fi
         else
-          if [[ ${{ inputs.package-dimension }} == big ]]; then
-            if [[ -f mutants_by_packages/regex_big.txt ]]; then
-              echo "Running mutants with shard ${{ inputs.shard }} on big packages"
-              cargo mutants --no-shuffle -vV -F "$(<mutants_by_packages/regex_big.txt)" -E ": replace .{1,2} with .{1,2} in " --shard ${{ inputs.shard }}/8 --output ./ --test-tool=nextest -- --all-targets --test-threads 1
+          if [[ ${{ inputs.package }} == stackslib ]]; then
+            if [[ -f mutants_by_packages/regex-stackslib.txt ]]; then
+              echo "Running mutants with shard ${{ inputs.shard }} on stackslib package"
+              cargo mutants --timeout-multiplier 1.5 --no-shuffle -vV -F "$(<mutants_by_packages/regex-stackslib.txt)" -E ": replace .{1,2} with .{1,2} in " --shard ${{ inputs.shard }}/8 --output ./ --test-tool=nextest -- --all-targets --test-threads 1
+              exit_code=$?
+            else
+              echo "File containing mutants doesn't exist!"
+            fi
+          elif [[ ${{ inputs.package }} == stacks-node ]]; then
+            if [[ -f mutants_by_packages/regex-stacks-node.txt ]]; then
+              echo "Running mutants with shard ${{ inputs.shard }} on stacks-node package"
+              cargo mutants --timeout-multiplier 1.5 --no-shuffle -vV -F "$(<mutants_by_packages/regex-stacks-node.txt)" -E ": replace .{1,2} with .{1,2} in " --shard ${{ inputs.shard }}/4 --output ./ --test-tool=nextest -- --all-targets --test-threads 1
               exit_code=$?
             else
               echo "File containing mutants doesn't exist!"
             fi
           else
-            if [[ -f mutants_by_packages/regex_small.txt ]]; then
+            if [[ -f mutants_by_packages/regex-small-packages.txt ]]; then
               echo "Running mutants with shard ${{ inputs.shard }} on small packages"
-              cargo mutants --no-shuffle -vV -F "$(<mutants_by_packages/regex_small.txt)" -E ": replace .{1,2} with .{1,2} in " --shard ${{ inputs.shard }}/4 --output ./ --test-tool=nextest -- --all-targets
+              cargo mutants --timeout-multiplier 1.5 --no-shuffle -vV -F "$(<mutants_by_packages/regex-small-packages.txt)" -E ": replace .{1,2} with .{1,2} in " --shard ${{ inputs.shard }}/4 --output ./ --test-tool=nextest -- --all-targets
               exit_code=$?
             else
               echo "File containing mutants doesn't exist!"
@@ -216,9 +247,9 @@ runs:
         fi
 
         # Create the folder only containing the outcomes (.txt files) and make a file containing the exit code of the command
-        mkdir mutants-shard-${{ inputs.package-dimension }}-${{ inputs.shard }}
-        echo "$exit_code" > ./mutants-shard-${{ inputs.package-dimension }}-${{ inputs.shard }}/exit_code.txt
-        mv ./mutants.out/*.txt mutants-shard-${{ inputs.package-dimension }}-${{ inputs.shard }}/
+        mkdir mutants-shard-${{ inputs.package }}-${{ inputs.shard }}
+        echo "$exit_code" > ./mutants-shard-${{ inputs.package }}-${{ inputs.shard }}/exit_code.txt
+        mv ./mutants.out/*.txt mutants-shard-${{ inputs.package }}-${{ inputs.shard }}/
 
         # Enable immediate exit on error again
         set -e
@@ -227,5 +258,5 @@ runs:
       id: upload_artifact
       uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
       with:
-        name: mutants-shard-${{ inputs.package-dimension }}-${{ inputs.shard }}
-        path: mutants-shard-${{ inputs.package-dimension }}-${{ inputs.shard }}
+        name: mutants-shard-${{ inputs.package }}-${{ inputs.shard }}
+        path: mutants-shard-${{ inputs.package }}-${{ inputs.shard }}

--- a/stacks-core/mutation-testing/pr-differences/action.yml
+++ b/stacks-core/mutation-testing/pr-differences/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: -1
   package-dimension:
-    description: "The dimension of the package. `big` for `stacks-node` and `stackslib`, `small` for others"
+    description: "The dimension of the package. `big` for `stacks-node` and `stackslib`, `small` for others, `stacks-signer` for `stacks-signer`."
     required: true
 
 runs:
@@ -54,38 +54,48 @@ runs:
         input_file="git.diff"
         temp_file="temp_diff_file.diff"
 
-        # Check if the commands exist on the host
-        for cmd in tac awk sed; do
-          command -v "${cmd}" > /dev/null 2>&1 || { echo "Missing command: ${cmd}" && exit 1; }
-        done
-
-        # Check that the file exists before performing actions on it
+        # Check if the file exists and is not empty
         if [ ! -s "$input_file" ]; then
-          echo "Diff file (git.diff) is missing or empty!"
+          echo "Diff file ($input_file) is missing or empty!"
           exit 1
         fi
 
-        # Reverse the file, remove 4 lines after '+++ /dev/null', then reverse it back (editors can't go backwards - to remove lines above)
-        tac "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
-        sed '/+++ \/dev\/null/{n;N;N;N;d;}' "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
-        tac "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
-
-        # Remove the lines between '+++ /dev/null' (included) and 'diff --git a/'
+        # Remove all lines related to deleted files including the first 'diff --git' line
         awk '
-          BEGIN { in_block=0 }
-          /\+\+\+ \/dev\/null/ { in_block=1; next }
-          in_block && /diff --git a\// { in_block=0; print; next }
-          !in_block
-        ' "$input_file" > "$temp_file"
+          /^diff --git/ {
+            diff_line = $0
+            getline
+            if ($0 ~ /^deleted file mode/) {
+              in_deleted_file_block = 1
+            } else {
+              if (diff_line != "") {
+                print diff_line
+                diff_line = ""
+              }
+              in_deleted_file_block = 0
+            }
+          }
+          !in_deleted_file_block
+        ' "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
 
-        # Check that the file exists before performing actions on it
-        if [ -s "$temp_file" ]; then
-          mv "$temp_file" "$input_file"
-          exit 0
-        fi
-
-        echo "Temp diff file (temp_diff_file.diff) is missing or empty!"
-        exit 1
+        # Remove 'diff --git' lines only when followed by 'similarity index', 'rename from', and 'rename to'
+        awk '
+          /^diff --git/ {
+            diff_line = $0
+            getline
+            if ($0 ~ /^similarity index/) {
+              getline
+              if ($0 ~ /^rename from/) {
+                getline
+                if ($0 ~ /^rename to/) {
+                  next
+                }
+              }
+            }
+            print diff_line  
+          }
+          { print }
+        ' "$input_file" > "$temp_file" && mv "$temp_file" "$input_file"
 
     - name: Split diffs
       id: split_diffs
@@ -120,6 +130,9 @@ runs:
             "testnet" | "stackslib")
               echo "$line" >> "mutants_by_packages/big_packages.txt"
               ;;
+            "stacks-signer")
+              echo "$line" >> "mutants_by_packages/stacks_signer.txt"
+              ;;
             *)
               echo "$line" >> "mutants_by_packages/small_packages.txt"
               ;;
@@ -139,6 +152,8 @@ runs:
 
           if [[ "$package" == "mutants_by_packages/big_packages.txt" ]]; then
             echo "$regex_pattern" > mutants_by_packages/regex_big.txt
+          elif [[ "$package" == "mutants_by_packages/stacks_signer.txt" ]]; then
+            echo "$regex_pattern" > mutants_by_packages/regex_stacks_signer.txt
           else
             echo "$regex_pattern" > mutants_by_packages/regex_small.txt
           fi
@@ -159,6 +174,14 @@ runs:
             if [[ -f mutants_by_packages/regex_big.txt ]]; then
               echo "Running mutants without shards on big packages"
               cargo mutants --no-shuffle -vV -F "$(<mutants_by_packages/regex_big.txt)" -E ": replace .{1,2} with .{1,2} in " --output ./ --test-tool=nextest -- --all-targets --test-threads 1
+              exit_code=$?
+            else
+              echo "File containing mutants doesn't exist!"
+            fi
+          elif [[ ${{ inputs.package-dimension }} == stacks-signer ]]; then
+            if [[ -f mutants_by_packages/regex_stacks_signer.txt ]]; then
+              echo "Found mutants on stacks-signer package, running them"
+              cargo mutants --no-shuffle -vV -F "$(<mutants_by_packages/regex_stacks_signer.txt)" -E ": replace .{1,2} with .{1,2} in " --output ./ --test-tool=nextest -- --all-targets --test-threads 1
               exit_code=$?
             else
               echo "File containing mutants doesn't exist!"

--- a/stacks-core/mutation-testing/pr-differences/action.yml
+++ b/stacks-core/mutation-testing/pr-differences/action.yml
@@ -198,12 +198,6 @@ runs:
             fi
           elif [[ ${{ inputs.package }} == stacks-signer ]]; then
             if [[ -f mutants_by_packages/regex-stacks-signer.txt ]]; then
-              # Run a basic cargo build (for debugging)
-              cargo build
-
-              # Run a basic cargo nextest (for debugging)
-              cargo nextest run -p stacks-signer --test-threads 1
-
               echo "Running mutants without shards on stacks-signer package"
               cargo mutants --timeout-multiplier 1.5 --no-shuffle -vV -F "$(<mutants_by_packages/regex-stacks-signer.txt)" -E ": replace .{1,2} with .{1,2} in " --output ./ --test-tool=nextest -- --all-targets --test-threads 1
               exit_code=$?


### PR DESCRIPTION
Updates:
1. split big packages into `stackslib` and `stacks-node`
2. update cargo mutants to use specific version from github in order to include a timeout multiplier feature
3. add a specific run case for `stacks-signer`