### PR TITLE
Move Checksum Step to Composite

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Monorepo of [composite actions](https://docs.github.com/en/actions/creating-acti
 - [codecov](./cleanup) - Uploads codecov reports with a retry if it fails (optionally it can run grcov to generate a report to send)
 - [openapi](./cleanup) - Generates and uploads an [OpenAPI](https://spec.openapis.org/oas/latest.html) artifact
 - [docker](./docker) - Generic Docker setup workflows
+- [generate-checksum](./generate-checksum/) - Generate a 512-bit `sha` hash of the uploaded artifacts
 - [stacks-core](./stacks-core/) - actions for the [stacks-core](https://github.com/stacks-network/stacks-core) repo
 
 ## Why does this exist?

--- a/generate-checksum/README.md
+++ b/generate-checksum/README.md
@@ -1,0 +1,26 @@
+# Generate Checksum action
+
+Generates a 512-bit `sha` hash for each file downloaded from artifacts.
+
+## Documentation
+
+### Inputs
+
+| Input | Description | Required | Default |
+| ------------------------------- | ----------------------------------------------------- | ------------------------- | ------------------------- |
+| `hashfile_name` | The name of the generated checksum file | false | "CHECKSUMS.txt" |
+
+## Usage
+
+```yaml
+name: Action
+on: push
+jobs:
+  build:
+    name: Job
+    runs-on: ubuntu-latest
+    steps:
+      - name: OpenAPI
+        id: openapi
+        uses: stacks-network/actions/generate-checksum@main
+```

--- a/generate-checksum/README.md
+++ b/generate-checksum/README.md
@@ -20,7 +20,7 @@ jobs:
     name: Job
     runs-on: ubuntu-latest
     steps:
-      - name: OpenAPI
-        id: openapi
+      - name: Generate Checksum
+        id: generate_checksum
         uses: stacks-network/actions/generate-checksum@main
 ```

--- a/generate-checksum/action.yml
+++ b/generate-checksum/action.yml
@@ -23,10 +23,13 @@ runs:
       id: generate_checksum
       shell: bash
       run: |
-        if command -v sha512sum > /dev/null 2>&1; then
-          echo "$(sha512sum release/* > ${{ inputs.hashfile_name }})";
-          exit 0;
-        else
+        if ! command -v sha512sum > /dev/null 2>&1; then
           echo "sha512sum command doesn't exist!";
           exit 1;
         fi
+
+        shasum="$(sha512sum release/*)"
+        echo "Generated checksums:"
+        echo "$shasum"
+        echo "$shasum > ${{ inputs.hashfile_name }})";
+        exit 0;

--- a/generate-checksum/action.yml
+++ b/generate-checksum/action.yml
@@ -31,5 +31,5 @@ runs:
         shasum="$(sha512sum release/*)"
         echo "Generated checksums:"
         echo "$shasum"
-        echo "$shasum > ${{ inputs.hashfile_name }})";
+        echo "$shasum" > "${{ inputs.hashfile_name }}";
         exit 0;

--- a/generate-checksum/action.yml
+++ b/generate-checksum/action.yml
@@ -2,14 +2,10 @@
 name: Generate Checksum
 
 inputs:
-  arch:
-    description: "Architecture to build binary for"
-    required: true
-    type: string
-  tag:
-    description: "Release Tag"
+  hashfile_name:
+    description: "The name of the generated checksum file"
     required: false
-    type: string
+    default: "CHECKSUMS.txt"
 
 runs:
   using: "composite"
@@ -28,7 +24,7 @@ runs:
       shell: bash
       run: |
         if command -v sha512sum > /dev/null 2>&1; then
-          echo "$(sha512sum release/*.zip > CHECKSUMS.txt)";
+          echo "$(sha512sum release/* > ${{ inputs.hashfile_name }})";
           exit 0;
         else
           echo "sha512sum command doesn't exist!";

--- a/generate-checksum/action.yml
+++ b/generate-checksum/action.yml
@@ -23,12 +23,19 @@ runs:
       id: generate_checksum
       shell: bash
       run: |
+        # If sha512sum command doesn't exist on the host, exit
         if ! command -v sha512sum > /dev/null 2>&1; then
           echo "sha512sum command doesn't exist!";
           exit 1;
         fi
 
+        # Generate the hashes and exit if the variable is empty
         shasum="$(sha512sum release/*)"
+        if [[ -z "$shasum" ]]; then
+          echo "Checksum could not be generated!";
+          exit 1;
+        fi
+
         echo "Generated checksums:"
         echo "$shasum"
         echo "$shasum" > "${{ inputs.hashfile_name }}";

--- a/stacks-core/create-source-binary/generate-checksum/action.yml
+++ b/stacks-core/create-source-binary/generate-checksum/action.yml
@@ -1,0 +1,36 @@
+## Github workflow to generate a sha512 checksum for the build archive
+name: Generate Checksum
+
+inputs:
+  arch:
+    description: "Architecture to build binary for"
+    required: true
+    type: string
+  tag:
+    description: "Release Tag"
+    required: false
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+    ## Downloads the artifacts built in `create-source-binary.yml`
+    - name: Download Artifacts
+      id: download_artifacts
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      with:
+        name: artifact
+        path: release
+
+    ## Generate a checksums file to be added to the release page
+    - name: Generate Checksums
+      id: generate_checksum
+      shell: bash
+      run: |
+        if command -v sha512sum > /dev/null 2>&1; then
+          echo "$(sha512sum release/*.zip > CHECKSUMS.txt)";
+          exit 0;
+        else
+          echo "sha512sum command doesn't exist!";
+          exit 1;
+        fi


### PR DESCRIPTION
Move the step that does checksum generation out of `stacks-core` repository, and change it to use bash instead of a predefined action.