### PR TITLE
Check Jobs Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Monorepo of [composite actions](https://docs.github.com/en/actions/creating-acti
 - [openapi](./cleanup) - Generates and uploads an [OpenAPI](https://spec.openapis.org/oas/latest.html) artifact
 - [docker](./docker) - Generic Docker setup workflows
 - [generate-checksum](./generate-checksum/) - Generate a 512-bit `sha` hash of the uploaded artifacts
+- [check-jobs-status](./check-jobs-status/) - Check the result of every job parsed as input. Only succeeds if none of the given jobs have failed.
 - [stacks-core](./stacks-core/) - actions for the [stacks-core](https://github.com/stacks-network/stacks-core) repo
 
 ## Why does this exist?

--- a/check-jobs-status/README.md
+++ b/check-jobs-status/README.md
@@ -1,0 +1,35 @@
+# Check Jobs Status action
+
+Check the result of all the jobs parsed as input to `jobs` (JSON object from `needs` context). If any job's result is a failure, this job will also fail.
+
+## Documentation
+
+### Inputs
+
+| Input | Description | Required | Default |
+| ------------------------------- | ----------------------------------------------------- | ------------------------- | ------------------------- |
+| `jobs` | A list of jobs from the `needs` context. | true | null |
+| `summary_print` | Print jobs status to GitHub Step Summary | false | "false" |
+
+## Usage
+
+```yaml
+name: Action
+on: push
+jobs:
+  check-jobs:
+    name: Check Jobs
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - job-1
+      - job-2
+      - job-3
+    steps:
+      - name: Check Jobs
+        id: check_jobs
+        uses: stacks-network/actions/check-jobs-status@main
+        with:
+          jobs: ${{ toJson(needs) }}
+          summary_print: "true"
+```

--- a/check-jobs-status/action.yml
+++ b/check-jobs-status/action.yml
@@ -22,19 +22,9 @@ runs:
 
         # Function to print output to GitHub Step Summary
         print_to_step_summary() {
-          echo "## Jobs Status" >> "$GITHUB_STEP_SUMMARY"
-
+          echo "### Jobs Status" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-
           echo "Some jobs that are required to succeed have failed." >> "$GITHUB_STEP_SUMMARY"
-
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-
-          echo "### Failed Jobs:" >> "$GITHUB_STEP_SUMMARY"
-
-          for job in "${failing_jobs[@]}"; do
-            echo "- **$job**" >> "$GITHUB_STEP_SUMMARY"
-          done
         }
 
         # Check that 'jq' command exists

--- a/check-jobs-status/action.yml
+++ b/check-jobs-status/action.yml
@@ -46,7 +46,7 @@ runs:
         # Search for failures and append them to a list
         for job_name in $(echo '${{ inputs.jobs }}' | jq -r 'keys[]'); do
           result=$(echo '${{ inputs.jobs }}' | jq -r ".[\"$job_name\"].result")
-          if [[ "$result" == "failure" ]]; then
+          if [[ "$result" != "success" ]]; then
             failing_jobs+=("$job_name")
           fi
         done

--- a/check-jobs-status/action.yml
+++ b/check-jobs-status/action.yml
@@ -19,7 +19,6 @@ runs:
       run: |
         # Check the jobs status and print the failures
         failing_jobs=()
-        successful_jobs=()
 
         # Function to print output to GitHub Step Summary
         print_to_step_summary() {
@@ -36,14 +35,6 @@ runs:
           for job in "${failing_jobs[@]}"; do
             echo "- **$job**" >> "$GITHUB_STEP_SUMMARY"
           done
-
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-
-          echo "### Successful Jobs:" >> "$GITHUB_STEP_SUMMARY"
-
-          for job in "${successful_jobs[@]}"; do
-            echo "- **$job**" >> "$GITHUB_STEP_SUMMARY"
-          done
         }
 
         # Check that 'jq' command exists
@@ -57,8 +48,6 @@ runs:
           result=$(echo '${{ inputs.jobs }}' | jq -r ".[\"$job_name\"].result")
           if [[ "$result" == "failure" ]]; then
             failing_jobs+=("$job_name")
-          else
-            successful_jobs+=("$job_name")
           fi
         done
 

--- a/check-jobs-status/action.yml
+++ b/check-jobs-status/action.yml
@@ -1,0 +1,81 @@
+## Github workflow to check that all jobs parsed as input from 'needs' are successful
+name: Check Jobs Status
+
+inputs:
+  jobs:
+    description: "A list of jobs from the `needs` context."
+    required: true
+  summary_print:
+    description: "Print jobs status to GitHub Step Summary"
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check Jobs
+      id: check_jobs
+      shell: bash
+      run: |
+        # Check the jobs status and print the failures
+        failing_jobs=()
+        successful_jobs=()
+
+        # Function to print output to GitHub Step Summary
+        print_to_step_summary() {
+          echo "## Jobs Status" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "Some jobs that are required to succeed have failed." >> "$GITHUB_STEP_SUMMARY"
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "### Failed Jobs:" >> "$GITHUB_STEP_SUMMARY"
+
+          for job in "${failing_jobs[@]}"; do
+            echo "- **$job**" >> "$GITHUB_STEP_SUMMARY"
+          done
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "### Successful Jobs:" >> "$GITHUB_STEP_SUMMARY"
+
+          for job in "${successful_jobs[@]}"; do
+            echo "- **$job**" >> "$GITHUB_STEP_SUMMARY"
+          done
+        }
+
+        # Check that 'jq' command exists
+        if ! command -v jq > /dev/null 2>&1; then
+          echo "jq command doesn't exist!";
+          exit 1;
+        fi
+
+        # Search for failures and append them to a list
+        for job_name in $(echo '${{ inputs.jobs }}' | jq -r 'keys[]'); do
+          result=$(echo '${{ inputs.jobs }}' | jq -r ".[\"$job_name\"].result")
+          if [[ "$result" == "failure" ]]; then
+            failing_jobs+=("$job_name")
+          else
+            successful_jobs+=("$job_name")
+          fi
+        done
+
+        # If there is no failing job, exit
+        if [[ ${#failing_jobs[@]} -eq 0 ]]; then
+          echo "All jobs were successful!"
+          exit 0
+        fi
+
+        # Print failing jobs to console
+        echo "Required jobs failed:"
+        for job in "${failing_jobs[@]}"; do
+          echo "- $job"
+        done
+
+        # If the 'summary_print' input is true, print jobs to GitHub Step Summary, then fail the job
+        if [[ "${{ inputs.summary_print }}" == "true" ]]; then
+          print_to_step_summary
+        fi
+        exit 1


### PR DESCRIPTION
Added composite action that is succeeding only if the status of all jobs parsed through the `inputs: jobs` field (from a JSON string of `needs` field in the main workflow) is `success`, otherwise it fails. The purpose of this action is to add the possibility of only making the job that calls this composite required in a ruleset instead of having each individual job required (i.e. each job from a matrix strategy).

Edit:
Reference run: https://github.com/BowTiedDevOps/stacks-core/actions/runs/7936200215?pr=2#summary-21671330780 (step summary print is disabled by default, can be activated with an input)