### PR TITLE
Disable Mutants on 'stacks-signer' Package

### DIFF
--- a/stacks-core/mutation-testing/check-packages-and-shards/action.yml
+++ b/stacks-core/mutation-testing/check-packages-and-shards/action.yml
@@ -171,7 +171,9 @@ runs:
 
         # If stacks_signer file exists and is not empty, run mutants on stacks-signer package
         if [[ -s mutants_by_packages/stacks-signer.txt ]]; then
-          echo "run_stacks_signer=true" >> "$GITHUB_OUTPUT"
+          # Disable mutants on 'stacks-signer' package for the moment due to unexpected failures
+          # echo "run_stacks_signer=true" >> "$GITHUB_OUTPUT"
+          echo "run_stacks_signer=false" >> "$GITHUB_OUTPUT"
         else
           echo "run_stacks_signer=false" >> "$GITHUB_OUTPUT"
         fi


### PR DESCRIPTION
Running mutants on stacks-signer causes the tests to fail unexpectedly when running `cargo nextest` within the `cargo mutants` command, but `cargo nextest` by itself works. Until the issue is solved, mutants should not be run on `stacks-signer` package.