### PR TITLE
Rust Format Action with Alias Input

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Monorepo of [composite actions](https://docs.github.com/en/actions/creating-acti
 - [docker](./docker) - Generic Docker setup workflows
 - [generate-checksum](./generate-checksum/) - Generate a 512-bit `sha` hash of the uploaded artifacts
 - [check-jobs-status](./check-jobs-status/) - Check the result of every job parsed as input. Only succeeds if none of the given jobs have failed.
+- [rustfmt](./rustfmt) - Run rustfmt for the given codebase
 - [stacks-core](./stacks-core/) - actions for the [stacks-core](https://github.com/stacks-network/stacks-core) repo
 
 ## Why does this exist?

--- a/rustfmt/README.md
+++ b/rustfmt/README.md
@@ -1,0 +1,45 @@
+# Rustfmt action
+
+Run `cargo fmt --all` and report all formatting differences in a nice overview.
+It works best in combination with [`actions-rust-lang/setup-rust-toolchain`] for [problem matcher] highlighting.
+
+## Documentation
+
+### Inputs
+
+All inputs are optional.
+If a [toolchain file](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) (i.e., `rust-toolchain` or `rust-toolchain.toml`) is found in the root of the repository, it takes precedence.
+All input values are ignored if a toolchain file exists.
+
+| Name            | Description                                                              | Default      |
+| --------------- | ------------------------------------------------------------------------ | ------------ |
+| `manifest-path` | Path to the `Cargo.toml` file, by default in the root of the repository. | `./Cargo.toml` |
+| `alias`         | The alias for cargo fmt (set in `.cargo/config`)                         | `fmt` |
+
+[`actions-rust-lang/setup-rust-toolchain`]: https://github.com/actions-rust-lang/setup-rust-toolchain
+[problem matcher]: https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md
+
+## Usage
+
+```yaml
+name: "Test Suite"
+on:
+  push:
+  pull_request:
+
+jobs:
+  formatting:
+    name: cargo fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Ensure rustfmt is installed and setup problem matcher
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt
+
+      - name: Rustfmt Check
+        uses: stacks-network/actions/rustfmt@main
+```
+

--- a/rustfmt/action.yml
+++ b/rustfmt/action.yml
@@ -23,7 +23,7 @@ runs:
       shell: bash
       run: |
         # Split alias command's options
-        alias="$(grep -e "${{ inputs.alias }}.*=" ./.cargo/config| tr -d '"' | awk '/^${{ inputs.alias }}[[:space:]]*=/ {sub(/^${{ inputs.alias }}[[:space:]]*=[[:space:]]*/, ""); print; exit}')"
+        alias=$(grep -e "${{ inputs.alias }}.*=" ./.cargo/config| tr -d '"' | awk '/^${{ inputs.alias }}[[:space:]]*=/ {sub(/^${{ inputs.alias }}[[:space:]]*=[[:space:]]*/, ""); print; exit}')
 
         before_empty_dashes=""
         after_empty_dashes=""

--- a/rustfmt/action.yml
+++ b/rustfmt/action.yml
@@ -23,7 +23,7 @@ runs:
       shell: bash
       run: |
         # Split alias command's options
-        alias=$(grep -e "${{ inputs.alias }}.*=" .cargo/config | tr -d '"' | awk '/^${{ inputs.alias }}[[:space:]]*=/ {sub(/^${{ inputs.alias }}[[:space:]]*=[[:space:]]*/, ""); print; exit}')
+        alias=$(grep -e "${{ inputs.alias }}[[:space:]]*=" .cargo/config | tr -d '"' | awk '/^${{ inputs.alias }}[[:space:]]*=/ {sub(/^${{ inputs.alias }}[[:space:]]*=[[:space:]]*/, ""); print; exit}')
 
         before_empty_dashes=""
         after_empty_dashes=""

--- a/rustfmt/action.yml
+++ b/rustfmt/action.yml
@@ -23,7 +23,7 @@ runs:
       shell: bash
       run: |
         # Split alias command's options
-        alias=$(grep -e "${{ inputs.alias }}[[:space:]]*=" .cargo/config | tr -d '"' | awk '/^${{ inputs.alias }}[[:space:]]*=/ {sub(/^${{ inputs.alias }}[[:space:]]*=[[:space:]]*/, ""); print; exit}')
+        alias=$(grep -e "${{ inputs.alias }}.*=" .cargo/config | tr -d '"' | awk '/^${{ inputs.alias }}[[:space:]]*=/ {sub(/^${{ inputs.alias }}[[:space:]]*=[[:space:]]*/, ""); print; exit}')
 
         before_empty_dashes=""
         after_empty_dashes=""

--- a/rustfmt/action.yml
+++ b/rustfmt/action.yml
@@ -23,7 +23,7 @@ runs:
       shell: bash
       run: |
         # Split alias command's options
-        alias=$(grep -e "${{ inputs.alias }}.*=" ./.cargo/config| tr -d '"' | awk '/^${{ inputs.alias }}[[:space:]]*=/ {sub(/^${{ inputs.alias }}[[:space:]]*=[[:space:]]*/, ""); print; exit}')
+        alias=$(grep -e "${{ inputs.alias }}.*=" .cargo/config | tr -d '"' | awk '/^${{ inputs.alias }}[[:space:]]*=/ {sub(/^${{ inputs.alias }}[[:space:]]*=[[:space:]]*/, ""); print; exit}')
 
         before_empty_dashes=""
         after_empty_dashes=""

--- a/rustfmt/action.yml
+++ b/rustfmt/action.yml
@@ -23,13 +23,15 @@ runs:
       shell: bash
       run: |
         # Split alias command's options
+        alias=$(grep -e "${{ inputs.alias }}.*=" ./.cargo/config| tr -d '"' | awk '/^${{ inputs.alias }}[[:space:]]*=/ {sub(/^${{ inputs.alias }}[[:space:]]*=[[:space:]]*/, ""); print; exit}'
+
         before_empty_dashes=""
         after_empty_dashes=""
         reached_empty_dashes=false
 
         IFS=' '
 
-        read -ra args <<< "${{ inputs.alias }}"
+        read -ra args <<< "$alias"
 
         if [[ "${args[0]}" != "fmt" ]]; then
           echo "The alias command is not 'fmt'!";

--- a/rustfmt/action.yml
+++ b/rustfmt/action.yml
@@ -1,0 +1,60 @@
+name: "Check formatting of Rust code with rustfmt"
+description: |
+  Run `cargo fmt` and check Rust code.
+  Highlights places which are not correctly formatted.
+branding:
+  icon: "check-square"
+  color: "yellow"
+
+inputs:
+  manifest-path:
+    description: "Specify the --manifest-path argument to rustfmt"
+    required: false
+    default: "./Cargo.toml"
+  alias:
+    description: "Fmt alias to run"
+    required: false
+    default: "fmt"
+
+runs:
+  using: composite
+  steps:
+    - name: Rustfmt Job Summary
+      shell: bash
+      run: |
+        # Run cargo and store the original output
+        CARGO_STATUS=0
+        CARGO_OUTPUT=$(cargo ${{ inputs.alias }} --all --manifest-path=${{ inputs.manifest-path }} -- --color=always --check 2>/dev/null) || CARGO_STATUS=$?
+
+        if [ ${CARGO_STATUS} -eq 0 ]; then
+            cat <<MARKDOWN_INTRO >> $GITHUB_STEP_SUMMARY
+        # Rustfmt Results
+
+        The code is formatted perfectly!
+        MARKDOWN_INTRO
+        else
+            cat <<MARKDOWN_INTRO >> $GITHUB_STEP_SUMMARY
+        # Rustfmt Results
+
+        \`cargo fmt\` reported formatting errors in the following locations.
+        You can fix them by executing the following command and committing the changes.
+        \`\`\`bash
+        cargo fmt --all
+        \`\`\`
+        MARKDOWN_INTRO
+
+            echo "${CARGO_OUTPUT}" |
+                # Strip color codes
+                sed 's/\x1B\[[0-9;]*[A-Za-z]//g' |
+                # Strip (some) cursor movements
+                sed 's/\x1B.[A-G]//g' |
+                tr "\n" "\r" |
+                # Wrap each location into a HTML details
+                sed -E 's#Diff in ([^\r]*?) at line ([[:digit:]]+):\r((:?[ +-][^\r]*\r)+)#<details>\n<summary>\1:\2</summary>\n\n```diff\n\3```\n\n</details>\n\n#g' |
+                tr "\r" "\n" >> $GITHUB_STEP_SUMMARY
+        fi
+
+        # Print the original cargo message
+        echo "${CARGO_OUTPUT}"
+        # Exit with the same status as cargo
+        exit "${CARGO_STATUS}"

--- a/rustfmt/action.yml
+++ b/rustfmt/action.yml
@@ -33,9 +33,8 @@ runs:
 
         read -ra args <<< "$alias"
 
-        if [[ "${args[0]}" != "fmt" ]]; then
-          echo "The alias command is not 'fmt'!";
-          exit 1;
+        if [[ "${args[0]}" != "fmt" && "${{ inputs.alias }}" != "fmt" ]]; then
+          echo "The provided alias is invalid!";
         fi
 
         for arg in "${args[@]}"; do
@@ -53,7 +52,7 @@ runs:
 
         # Run cargo and store the original output
         CARGO_STATUS=0
-        CARGO_OUTPUT=$(cargo $before_empty_dashes --all --manifest-path=${{ inputs.manifest-path }} -- $after_empty_dashes --color=always --check 2>/dev/null) || CARGO_STATUS=$?
+        CARGO_OUTPUT=$(cargo ${before_empty_dashes:-fmt} --all --manifest-path=${{ inputs.manifest-path }} -- $after_empty_dashes --color=always --check 2>/dev/null) || CARGO_STATUS=$?
 
         if [ ${CARGO_STATUS} -eq 0 ]; then
             cat <<MARKDOWN_INTRO >> $GITHUB_STEP_SUMMARY

--- a/rustfmt/action.yml
+++ b/rustfmt/action.yml
@@ -36,10 +36,10 @@ runs:
             cat <<MARKDOWN_INTRO >> $GITHUB_STEP_SUMMARY
         # Rustfmt Results
 
-        \`cargo fmt\` reported formatting errors in the following locations.
+        \`cargo ${{ inputs.alias }}\` reported formatting errors in the following locations.
         You can fix them by executing the following command and committing the changes.
         \`\`\`bash
-        cargo fmt --all
+        cargo ${{ inputs.alias }} --all
         \`\`\`
         MARKDOWN_INTRO
 

--- a/rustfmt/action.yml
+++ b/rustfmt/action.yml
@@ -22,9 +22,36 @@ runs:
     - name: Rustfmt Job Summary
       shell: bash
       run: |
+        # Split alias command's options
+        before_empty_dashes=""
+        after_empty_dashes=""
+        reached_empty_dashes=false
+
+        IFS=' '
+
+        read -ra args <<< "${{ inputs.alias }}"
+
+        if [[ "${args[0]}" != "fmt" ]]; then
+          echo "The alias command is not 'fmt'!";
+          exit 1;
+        fi
+
+        for arg in "${args[@]}"; do
+          if [[ "$arg" == "--" ]]; then
+            reached_empty_dashes=true;
+            continue;
+          fi
+
+          if $reached_empty_dashes; then
+            after_empty_dashes="$after_empty_dashes $arg";
+          else
+            before_empty_dashes="$before_empty_dashes $arg";
+          fi
+        done
+
         # Run cargo and store the original output
         CARGO_STATUS=0
-        CARGO_OUTPUT=$(cargo ${{ inputs.alias }} --all --manifest-path=${{ inputs.manifest-path }} -- --color=always --check 2>/dev/null) || CARGO_STATUS=$?
+        CARGO_OUTPUT=$(cargo $before_empty_dashes --all --manifest-path=${{ inputs.manifest-path }} -- $after_empty_dashes --color=always --check 2>/dev/null) || CARGO_STATUS=$?
 
         if [ ${CARGO_STATUS} -eq 0 ]; then
             cat <<MARKDOWN_INTRO >> $GITHUB_STEP_SUMMARY

--- a/rustfmt/action.yml
+++ b/rustfmt/action.yml
@@ -64,10 +64,10 @@ runs:
             cat <<MARKDOWN_INTRO >> $GITHUB_STEP_SUMMARY
         # Rustfmt Results
 
-        \`cargo ${{ inputs.alias }}\` reported formatting errors in the following locations.
+        \`cargo fmt\` reported formatting errors in the following locations.
         You can fix them by executing the following command and committing the changes.
         \`\`\`bash
-        cargo ${{ inputs.alias }} --all
+        cargo fmt --all
         \`\`\`
         MARKDOWN_INTRO
 

--- a/rustfmt/action.yml
+++ b/rustfmt/action.yml
@@ -23,7 +23,7 @@ runs:
       shell: bash
       run: |
         # Split alias command's options
-        alias=$(grep -e "${{ inputs.alias }}.*=" ./.cargo/config| tr -d '"' | awk '/^${{ inputs.alias }}[[:space:]]*=/ {sub(/^${{ inputs.alias }}[[:space:]]*=[[:space:]]*/, ""); print; exit}'
+        alias="$(grep -e "${{ inputs.alias }}.*=" ./.cargo/config| tr -d '"' | awk '/^${{ inputs.alias }}[[:space:]]*=/ {sub(/^${{ inputs.alias }}[[:space:]]*=[[:space:]]*/, ""); print; exit}')"
 
         before_empty_dashes=""
         after_empty_dashes=""


### PR DESCRIPTION
I've cloned the [rustfmt](https://github.com/actions-rust-lang/rustfmt) action and modified it to run `cargo fmt` with the possibility of giving it an alias to run. It reads the `.cargo/config` file trying to find the command given for the alias, checks that it is `fmt` and then iterates through the options in the alias and parses them to the CI fmt check command.

Action run: https://github.com/BowTiedDevOps/stacks-core/actions/runs/8099932805#summary-22174755421