### PR TITLE
Add stacks-core binary builds

### DIFF
--- a/stacks-core/create-source-binary/README.md
+++ b/stacks-core/create-source-binary/README.md
@@ -10,6 +10,7 @@ Builds a binary for the given architecture and uploads it to artifacts.
 | ---------------- | ----------------------------- | -------- | ------------------------ |
 | `arch`           | Binary's build architecture   | `true`   | null                     |
 | `tag`            | The tag for the release       | `false`  | null                     |
+| `cpu`            | The target CPU                | `true`   | null                     |
 
 ## Usage
 
@@ -27,4 +28,5 @@ jobs:
         with:
           arch: linux-glibc-x64
           tag: 2.4.0.1.0-rc2
+          cpu: native
 ```

--- a/stacks-core/create-source-binary/README.md
+++ b/stacks-core/create-source-binary/README.md
@@ -6,11 +6,11 @@ Builds a binary for the given architecture and uploads it to artifacts.
 
 ### Inputs
 
-| Input            | Description                   | Required | Default                  |
-| ---------------- | ----------------------------- | -------- | ------------------------ |
-| `arch`           | Binary's build architecture   | `true`   | null                     |
-| `tag`            | The tag for the release       | `false`  | null                     |
-| `cpu`            | The target CPU                | `true`   | null                     |
+| Input  | Description                 | Required | Default |
+| ------ | --------------------------- | -------- | ------- |
+| `arch` | Binary's build architecture | `true`   | null    |
+| `tag`  | The tag for the release     | `true`   | null    |
+| `cpu`  | The target CPU              | `true`   | null    |
 
 ## Usage
 
@@ -26,7 +26,7 @@ jobs:
         id: build_binary
         uses: stacks-network/actions/stacks-core/create-source-binary@main
         with:
-          arch: linux-glibc-x64
+          arch: linux-glibc
+          cpu: x86-64
           tag: 2.4.0.1.0-rc2
-          cpu: native
 ```

--- a/stacks-core/create-source-binary/action.yml
+++ b/stacks-core/create-source-binary/action.yml
@@ -28,33 +28,41 @@ runs:
           echo "archive_name=${{ inputs.arch }}_${{ inputs.cpu }}.zip >> "$GITHUB_ENV"
         fi
 
-    ## Setup Docker for the builds
-    - name: Docker setup
-      uses: stacks-network/actions/docker@main
-
-    ## Build the binaries using defined dockerfiles
-    - name: Build Binary (${{ env.archive_name }})
-      id: build_binaries
-      uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # 5.0.0
-      with:
-        file: build-scripts/Dockerfile.${{ inputs.arch }}
-        outputs: type=local,dest=./release/${{ inputs.arch }}
-        build-args: |
-          STACKS_NODE_VERSION=${{ inputs.tag || env.GITHUB_SHA_SHORT }}
-          OS_ARCH=${{ inputs.arch }}
-          TARGET_CPU=${{ inputs.cpu }}
-          GIT_BRANCH=${{ env.GITHUB_REF_SHORT }}
-          GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
-
-    ## Compress the binary artifact
-    - name: Compress artifact
-      id: compress_artifact
+    - name: Test Prints
       shell: bash
-      run: zip --junk-paths ${{ inputs.arch }} ./release/${{ inputs.arch }}/*
+      run: |
+        echo "**Job Info**" >> "$GITHUB_STEP_SUMMARY"
+        echo "- Archive name: ${{ env.archive_name }}" >> "$GITHUB_STEP_SUMMARY"
+        echo "- OS Architecture: ${{ inputs.arch }}" >> "$GITHUB_STEP_SUMMARY"
+        echo "- Target CPU: ${{ inputs.cpu }}" >> "$GITHUB_STEP_SUMMARY"
 
-    ## Upload the binary artifact to the github action
-    - name: Upload artifact
-      id: upload_artifact
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
-      with:
-        path: ${{ env.archive_name }}
+    # ## Setup Docker for the builds
+    # - name: Docker setup
+    #   uses: stacks-network/actions/docker@main
+
+    # ## Build the binaries using defined dockerfiles
+    # - name: Build Binary (${{ env.archive_name }})
+    #   id: build_binaries
+    #   uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # 5.0.0
+    #   with:
+    #     file: build-scripts/Dockerfile.${{ inputs.arch }}
+    #     outputs: type=local,dest=./release/${{ inputs.arch }}
+    #     build-args: |
+    #       STACKS_NODE_VERSION=${{ inputs.tag || env.GITHUB_SHA_SHORT }}
+    #       OS_ARCH=${{ inputs.arch }}
+    #       TARGET_CPU=${{ inputs.cpu }}
+    #       GIT_BRANCH=${{ env.GITHUB_REF_SHORT }}
+    #       GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
+
+    # ## Compress the binary artifact
+    # - name: Compress artifact
+    #   id: compress_artifact
+    #   shell: bash
+    #   run: zip --junk-paths ${{ inputs.arch }} ./release/${{ inputs.arch }}/*
+
+    # ## Upload the binary artifact to the github action
+    # - name: Upload artifact
+    #   id: upload_artifact
+    #   uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+    #   with:
+    #     path: ${{ env.archive_name }}

--- a/stacks-core/create-source-binary/action.yml
+++ b/stacks-core/create-source-binary/action.yml
@@ -1,48 +1,80 @@
 ## Github workflow to create multiarch binaries from source
 name: Create Binaries
+description: "Create Binary Archives"
+branding:
+  icon: "archive"
+  color: "gray-dark"
 
 inputs:
   arch:
     description: "Architecture to build binary for"
     required: true
-    type: string
+  cpu:
+    description: "CPU to build binary for"
+    required: true
   tag:
     description: "Release Tag"
-    required: false
-    type: string
-  cpu:
-    description: "The target CPU"
     required: true
-    type: string
 
 runs:
   using: "composite"
   steps:
-    ## Set the archive name based on the target cpu
-    - name: Set Archive Name
-      id: set_archive_name
-      shell: bash
-      run: |
-        echo "archive-name=${{ inputs.arch }}.zip" >> "$GITHUB_ENV"
-        if [[ ${{ matrix.cpu }} == *v3* ]]; then
-          echo "archive_name=${{ inputs.arch }}_${{ inputs.cpu }}.zip" >> "$GITHUB_ENV"
-        fi
-
     ## Setup Docker for the builds
     - name: Docker setup
+      id: docker_setup
       uses: stacks-network/actions/docker@main
 
+    ## Set env vars based on the type of arch build
+    - name: Set local env vars
+      id: set_env
+      shell: bash
+      run: |
+        case ${{ inputs.cpu }} in
+          x86-64)
+            ## default x64 builds to use v3 variant. TARGET_CPU is required to build for v3 via RUSTFLAGS
+            TARGET_CPU="${{ inputs.cpu }}-v3"
+            DOCKERFILE_CPU="x64"
+            ARCHIVE_NAME="x64"
+            ;;
+          x86-64-v2)
+            ## intel nehalem (2008) and newer
+            TARGET_CPU="${{ inputs.cpu }}"
+            DOCKERFILE_CPU="x64"
+            ARCHIVE_NAME="x64-v2"
+            ;;
+          x86-64-v3)
+            ## intel haswell (2013) and newer
+            TARGET_CPU="${{ inputs.cpu }}"
+            DOCKERFILE_CPU="x64"
+            ARCHIVE_NAME="x64-v3"
+            ;;
+          x86-64-v4)
+            ## intel skylake (2017) and newer
+            TARGET_CPU="${{ inputs.cpu }}"
+            DOCKERFILE_CPU="x64"
+            ARCHIVE_NAME="x64-v4"
+            ;;
+          *)
+            TARGET_CPU=""
+            DOCKERFILE_CPU="${{ inputs.cpu }}"
+            ARCHIVE_NAME="${{ inputs.cpu }}"
+            ;;
+        esac
+        echo "DOCKERFILE=Dockerfile.${{ inputs.arch }}-${DOCKERFILE_CPU}" >> "$GITHUB_ENV"
+        echo "ZIPFILE=${{ inputs.arch }}-${ARCHIVE_NAME}" >> "$GITHUB_ENV"
+        echo "TARGET_CPU=${TARGET_CPU}" >> "$GITHUB_ENV"
+
     ## Build the binaries using defined dockerfiles
-    - name: Build Binary (${{ env.archive_name }})
+    - name: Build Binary (${{ inputs.arch }}_${{ inputs.cpu }})
       id: build_binaries
       uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # 5.0.0
       with:
-        file: build-scripts/Dockerfile.${{ inputs.arch }}
+        file: build-scripts/${{ env.DOCKERFILE }}
         outputs: type=local,dest=./release/${{ inputs.arch }}
         build-args: |
           STACKS_NODE_VERSION=${{ inputs.tag || env.GITHUB_SHA_SHORT }}
           OS_ARCH=${{ inputs.arch }}
-          TARGET_CPU=${{ inputs.cpu }}
+          TARGET_CPU=${{ env.TARGET_CPU }}
           GIT_BRANCH=${{ env.GITHUB_REF_SHORT }}
           GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
 
@@ -50,11 +82,12 @@ runs:
     - name: Compress artifact
       id: compress_artifact
       shell: bash
-      run: zip --junk-paths ${{ inputs.arch }} ./release/${{ inputs.arch }}/*
+      run: |
+        zip --junk-paths ${{ env.ZIPFILE }} ./release/${{ inputs.arch }}/*
 
-    ## Upload the binary artifact to the github action
+    ## Upload the binary artifact to the github action (used in `github-release.yml` to create a release)
     - name: Upload artifact
       id: upload_artifact
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
-        path: ${{ env.archive_name }}
+        path: ${{ env.ZIPFILE }}.zip

--- a/stacks-core/create-source-binary/action.yml
+++ b/stacks-core/create-source-binary/action.yml
@@ -7,10 +7,10 @@ branding:
 
 inputs:
   arch:
-    description: "Architecture to build binary for"
+    description: "Architecture to build binary"
     required: true
   cpu:
-    description: "CPU to build binary for"
+    description: "CPU to build binary"
     required: true
   tag:
     description: "Release Tag"
@@ -69,7 +69,7 @@ runs:
       id: build_binaries
       uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # 5.0.0
       with:
-        file: build-scripts/${{ env.DOCKERFILE }}
+        file: ${{ github.action_path }}/build-scripts/${{ env.DOCKERFILE }}
         outputs: type=local,dest=./release/${{ inputs.arch }}
         build-args: |
           STACKS_NODE_VERSION=${{ inputs.tag || env.GITHUB_SHA_SHORT }}

--- a/stacks-core/create-source-binary/action.yml
+++ b/stacks-core/create-source-binary/action.yml
@@ -23,9 +23,9 @@ runs:
       id: set_archive_name
       shell: bash
       run: |
-        echo "archive-name=${{ inputs.arch }}.zip >> "$GITHUB_ENV"
+        echo "archive-name=${{ inputs.arch }}.zip" >> "$GITHUB_ENV"
         if [[ ${{ matrix.cpu }} == *x86* ]]; then
-          echo "archive_name=${{ inputs.arch }}_${{ inputs.cpu }}.zip >> "$GITHUB_ENV"
+          echo "archive_name=${{ inputs.arch }}_${{ inputs.cpu }}.zip" >> "$GITHUB_ENV"
         fi
 
     - name: Test Prints

--- a/stacks-core/create-source-binary/action.yml
+++ b/stacks-core/create-source-binary/action.yml
@@ -18,12 +18,22 @@ inputs:
 runs:
   using: "composite"
   steps:
+    ## Set the archive name based on the target cpu
+    - name: Set Archive Name
+      id: set_archive_name
+      shell: bash
+      run: |
+        echo "archive-name=${{ inputs.arch }}.zip >> "$GITHUB_ENV"
+        if [[ ${{ matrix.cpu }} == *x86* ]]; then
+          echo "archive_name=${{ inputs.arch }}_${{ inputs.cpu }}.zip >> "$GITHUB_ENV"
+        fi
+
     ## Setup Docker for the builds
     - name: Docker setup
       uses: stacks-network/actions/docker@main
 
     ## Build the binaries using defined dockerfiles
-    - name: Build Binary (${{ inputs.arch }}_${{ inputs.cpu }})
+    - name: Build Binary (${{ env.archive_name }})
       id: build_binaries
       uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # 5.0.0
       with:
@@ -47,4 +57,4 @@ runs:
       id: upload_artifact
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
-        path: ${{ inputs.arch }}.zip
+        path: ${{ env.archive_name }}

--- a/stacks-core/create-source-binary/action.yml
+++ b/stacks-core/create-source-binary/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: "Release Tag"
     required: false
     type: string
+  cpu:
+    description: "The target CPU"
+    required: true
+    type: string
 
 runs:
   using: "composite"
@@ -19,7 +23,7 @@ runs:
       uses: stacks-network/actions/docker@main
 
     ## Build the binaries using defined dockerfiles
-    - name: Build Binary (${{ inputs.arch }})
+    - name: Build Binary (${{ inputs.arch }}_${{ inputs.cpu }})
       id: build_binaries
       uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # 5.0.0
       with:
@@ -28,6 +32,7 @@ runs:
         build-args: |
           STACKS_NODE_VERSION=${{ inputs.tag || env.GITHUB_SHA_SHORT }}
           OS_ARCH=${{ inputs.arch }}
+          TARGET_CPU=${{ inputs.cpu }}
           GIT_BRANCH=${{ env.GITHUB_REF_SHORT }}
           GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
 

--- a/stacks-core/create-source-binary/action.yml
+++ b/stacks-core/create-source-binary/action.yml
@@ -24,45 +24,37 @@ runs:
       shell: bash
       run: |
         echo "archive-name=${{ inputs.arch }}.zip" >> "$GITHUB_ENV"
-        if [[ ${{ matrix.cpu }} == *x86* ]]; then
+        if [[ ${{ matrix.cpu }} == *v3* ]]; then
           echo "archive_name=${{ inputs.arch }}_${{ inputs.cpu }}.zip" >> "$GITHUB_ENV"
         fi
 
-    - name: Test Prints
+    ## Setup Docker for the builds
+    - name: Docker setup
+      uses: stacks-network/actions/docker@main
+
+    ## Build the binaries using defined dockerfiles
+    - name: Build Binary (${{ env.archive_name }})
+      id: build_binaries
+      uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # 5.0.0
+      with:
+        file: build-scripts/Dockerfile.${{ inputs.arch }}
+        outputs: type=local,dest=./release/${{ inputs.arch }}
+        build-args: |
+          STACKS_NODE_VERSION=${{ inputs.tag || env.GITHUB_SHA_SHORT }}
+          OS_ARCH=${{ inputs.arch }}
+          TARGET_CPU=${{ inputs.cpu }}
+          GIT_BRANCH=${{ env.GITHUB_REF_SHORT }}
+          GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
+
+    ## Compress the binary artifact
+    - name: Compress artifact
+      id: compress_artifact
       shell: bash
-      run: |
-        echo "**Job Info**" >> "$GITHUB_STEP_SUMMARY"
-        echo "- Archive name: ${{ env.archive_name }}" >> "$GITHUB_STEP_SUMMARY"
-        echo "- OS Architecture: ${{ inputs.arch }}" >> "$GITHUB_STEP_SUMMARY"
-        echo "- Target CPU: ${{ inputs.cpu }}" >> "$GITHUB_STEP_SUMMARY"
+      run: zip --junk-paths ${{ inputs.arch }} ./release/${{ inputs.arch }}/*
 
-    # ## Setup Docker for the builds
-    # - name: Docker setup
-    #   uses: stacks-network/actions/docker@main
-
-    # ## Build the binaries using defined dockerfiles
-    # - name: Build Binary (${{ env.archive_name }})
-    #   id: build_binaries
-    #   uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # 5.0.0
-    #   with:
-    #     file: build-scripts/Dockerfile.${{ inputs.arch }}
-    #     outputs: type=local,dest=./release/${{ inputs.arch }}
-    #     build-args: |
-    #       STACKS_NODE_VERSION=${{ inputs.tag || env.GITHUB_SHA_SHORT }}
-    #       OS_ARCH=${{ inputs.arch }}
-    #       TARGET_CPU=${{ inputs.cpu }}
-    #       GIT_BRANCH=${{ env.GITHUB_REF_SHORT }}
-    #       GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
-
-    # ## Compress the binary artifact
-    # - name: Compress artifact
-    #   id: compress_artifact
-    #   shell: bash
-    #   run: zip --junk-paths ${{ inputs.arch }} ./release/${{ inputs.arch }}/*
-
-    # ## Upload the binary artifact to the github action
-    # - name: Upload artifact
-    #   id: upload_artifact
-    #   uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
-    #   with:
-    #     path: ${{ env.archive_name }}
+    ## Upload the binary artifact to the github action
+    - name: Upload artifact
+      id: upload_artifact
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      with:
+        path: ${{ env.archive_name }}

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-arm64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-arm64
@@ -1,4 +1,4 @@
-FROM rust:bullseye as build
+FROM rust:bookworm as build
 
 ARG STACKS_NODE_VERSION="No Version Info"
 ARG GIT_BRANCH='No Branch Info'

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-armv7
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-armv7
@@ -1,4 +1,4 @@
-FROM rust:bullseye as build
+FROM rust:bookworm as build
 
 ARG STACKS_NODE_VERSION="No Version Info"
 ARG GIT_BRANCH='No Branch Info'

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-x64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-x64
@@ -1,4 +1,4 @@
-FROM rust:bullseye as build
+FROM rust:bookworm as build
 
 ARG STACKS_NODE_VERSION="No Version Info"
 ARG GIT_BRANCH='No Branch Info'
@@ -7,6 +7,7 @@ ARG BUILD_DIR=/build
 ARG TARGET=x86_64-unknown-linux-gnu
 # Allow us to override the default `--target-cpu` for the given target triplet
 ARG TARGET_CPU
+ENV RUSTFLAGS="${TARGET_CPU:+${RUSTFLAGS} -Ctarget-cpu=${TARGET_CPU}}"
 WORKDIR /src
 
 COPY . .
@@ -17,8 +18,7 @@ RUN apt-get update && apt-get install -y git
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
-    ${TARGET_CPU:+RUSTFLAGS="$RUSTFLAGS $TARGET_CPU"} \
-    cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
+    && cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
     && mkdir -p /out \
     && cp -R ${BUILD_DIR}/target/${TARGET}/release/. /out
 

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-x64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-x64
@@ -5,6 +5,8 @@ ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 ARG BUILD_DIR=/build
 ARG TARGET=x86_64-unknown-linux-gnu
+# Allow us to override the default `--target-cpu` for the given target triplet
+ARG TARGET_CPU
 WORKDIR /src
 
 COPY . .
@@ -15,7 +17,8 @@ RUN apt-get update && apt-get install -y git
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
-    && cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
+    ${TARGET_CPU:+RUSTFLAGS="$RUSTFLAGS $TARGET_CPU"} \
+    cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
     && mkdir -p /out \
     && cp -R ${BUILD_DIR}/target/${TARGET}/release/. /out
 

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-musl-x64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-musl-x64
@@ -5,6 +5,8 @@ ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 ARG BUILD_DIR=/build
 ARG TARGET=x86_64-unknown-linux-musl
+# Allow us to override the default `--target-cpu` for the given target triplet
+ARG TARGET_CPU
 WORKDIR /src
 
 COPY . .
@@ -15,7 +17,8 @@ RUN apk update && apk add git musl-dev
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
-    && cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
+    ${TARGET_CPU:+RUSTFLAGS="$RUSTFLAGS $TARGET_CPU"} \
+    cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
     && mkdir -p /out \
     && cp -R ${BUILD_DIR}/target/${TARGET}/release/. /out
 

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-musl-x64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-musl-x64
@@ -5,22 +5,22 @@ ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 ARG BUILD_DIR=/build
 ARG TARGET=x86_64-unknown-linux-musl
-# Allow us to override the default `--target-cpu` for the given target triplet
 ARG TARGET_CPU
+ENV RUSTFLAGS="${TARGET_CPU:+${RUSTFLAGS} -Ctarget-cpu=${TARGET_CPU}}"
 WORKDIR /src
 
 COPY . .
 
-RUN apk update && apk add git musl-dev
+RUN apk update && apk add git musl-dev make
 
 # Run all the build steps in ramdisk in an attempt to speed things up
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
-    ${TARGET_CPU:+RUSTFLAGS="$RUSTFLAGS $TARGET_CPU"} \
-    cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
+    && cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
     && mkdir -p /out \
     && cp -R ${BUILD_DIR}/target/${TARGET}/release/. /out
 
 FROM scratch AS export-stage
 COPY --from=build /out/stacks-inspect /out/blockstack-cli /out/clarity-cli /out/stacks-node /
+

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.macos-x64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.macos-x64
@@ -6,8 +6,8 @@ ARG GIT_COMMIT='No Commit Info'
 ARG BUILD_DIR=/build
 ARG OSXCROSS="https://github.com/hirosystems/docker-osxcross-rust/releases/download/MacOSX12.0.sdk/osxcross-d904031_MacOSX12.0.sdk.tar.zst"
 ARG TARGET=x86_64-apple-darwin
-# Allow us to override the default `--target-cpu` for the given target triplet
 ARG TARGET_CPU
+ENV RUSTFLAGS="${TARGET_CPU:+${RUSTFLAGS} -Ctarget-cpu=${TARGET_CPU}}"
 WORKDIR /src
 
 COPY . .
@@ -23,8 +23,7 @@ RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
     && . /opt/osxcross/env-macos-x86_64 \
-    ${TARGET_CPU:+RUSTFLAGS="$RUSTFLAGS $TARGET_CPU"} \
-    cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
+    && cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
     && mkdir -p /out \
     && cp -R ${BUILD_DIR}/target/${TARGET}/release/. /out
 

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.macos-x64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.macos-x64
@@ -6,6 +6,8 @@ ARG GIT_COMMIT='No Commit Info'
 ARG BUILD_DIR=/build
 ARG OSXCROSS="https://github.com/hirosystems/docker-osxcross-rust/releases/download/MacOSX12.0.sdk/osxcross-d904031_MacOSX12.0.sdk.tar.zst"
 ARG TARGET=x86_64-apple-darwin
+# Allow us to override the default `--target-cpu` for the given target triplet
+ARG TARGET_CPU
 WORKDIR /src
 
 COPY . .
@@ -21,7 +23,8 @@ RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
     && . /opt/osxcross/env-macos-x86_64 \
-    && cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
+    ${TARGET_CPU:+RUSTFLAGS="$RUSTFLAGS $TARGET_CPU"} \
+    cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
     && mkdir -p /out \
     && cp -R ${BUILD_DIR}/target/${TARGET}/release/. /out
 

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.windows-x64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.windows-x64
@@ -5,6 +5,8 @@ ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 ARG BUILD_DIR=/build
 ARG TARGET=x86_64-pc-windows-gnu
+# Allow us to override the default `--target-cpu` for the given target triplet
+ARG TARGET_CPU
 WORKDIR /src
 
 COPY . .
@@ -17,6 +19,7 @@ RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && rustup target add ${TARGET} \
     && CC_x86_64_pc_windows_gnu=x86_64-w64-mingw32-gcc \
     CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=x86_64-w64-mingw32-gcc \
+    ${TARGET_CPU:+RUSTFLAGS="$RUSTFLAGS $TARGET_CPU"} \
     cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
     && mkdir -p /out \
     && cp -R ${BUILD_DIR}/target/${TARGET}/release/. /out

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.windows-x64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.windows-x64
@@ -1,17 +1,17 @@
-FROM rust:bullseye as build
+FROM rust:bookworm as build
 
 ARG STACKS_NODE_VERSION="No Version Info"
 ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 ARG BUILD_DIR=/build
 ARG TARGET=x86_64-pc-windows-gnu
-# Allow us to override the default `--target-cpu` for the given target triplet
 ARG TARGET_CPU
+ENV RUSTFLAGS="${TARGET_CPU:+${RUSTFLAGS} -Ctarget-cpu=${TARGET_CPU}}"
 WORKDIR /src
 
 COPY . .
 
-RUN apt-get update && apt-get install -y git gcc-mingw-w64-x86-64
+RUN apt-get update && apt-get install -y git gcc-mingw-w64-x86-64 libclang-dev
 
 # Run all the build steps in ramdisk in an attempt to speed things up
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
@@ -19,7 +19,6 @@ RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && rustup target add ${TARGET} \
     && CC_x86_64_pc_windows_gnu=x86_64-w64-mingw32-gcc \
     CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=x86_64-w64-mingw32-gcc \
-    ${TARGET_CPU:+RUSTFLAGS="$RUSTFLAGS $TARGET_CPU"} \
     cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
     && mkdir -p /out \
     && cp -R ${BUILD_DIR}/target/${TARGET}/release/. /out


### PR DESCRIPTION
moves the binary build process from https://github.com/stacks-network/stacks-core/tree/master/build-scripts to a composite action. 

requires a corresponding change in the calling workflow @BowTiedDevOps  -https://github.com/stacks-network/stacks-core/blob/master/.github/workflows/create-source-binary.yml

ex:
```yml
## Github workflow to create multiarch binaries from source

name: Create Binaries

on:
  workflow_call:
    inputs:
      tag:
        description: "Tag name of this release (x.y.z)"
        required: true
        type: string

## change the display name to the tag being built
run-name: ${{ inputs.tag }}

concurrency:
  group: create-binary-${{ github.head_ref || github.ref || github.run_id}}
  ## Only cancel in progress if this is for a PR
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}

jobs:
  ## Runs when the following is true:
  ##  - tag is provided
  ##  - workflow is building default branch (master)
  artifact:
    if: |
      inputs.tag != '' &&
      github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
    name: Build Binaries
    runs-on: ubuntu-latest
    strategy:
      ## Run a maximum of 10 builds concurrently, using the matrix defined in inputs.arch
      max-parallel: 10
      matrix:
        arch:
          - linux-musl
          - linux-glibc
          - macos
          - windows
        cpu:
          - arm64
          - armv7
          - x86-64 ## defaults to x86-64-v3 variant - intel haswell (2013) and newer
          # - x86-64-v2 ## intel nehalem (2008) and newer
          # - x86-64-v3 ## intel haswell (2013) and newer
          # - x86-64-v4 ## intel skylake (2017) and newer
        exclude:
          - arch: windows # excludes windows-arm64
            cpu: arm64
          - arch: windows # excludes windows-armv7
            cpu: armv7
          - arch: macos # excludes macos-armv7
            cpu: armv7

    steps:
      - name: Build Binary (${{ matrix.arch }}_${{ matrix.cpu }})
        id: build_binary
        uses: stacks-network/actions/stacks-core/create-source-binary@main
        with:
          arch: ${{ matrix.arch }}
          cpu: ${{ matrix.cpu }}
          tag: ${{ inputs.tag }}
  ```