### PR TITLE
Fix Mutants Installation

### DIFF
--- a/stacks-core/mutation-testing/check-packages-and-shards/action.yml
+++ b/stacks-core/mutation-testing/check-packages-and-shards/action.yml
@@ -41,7 +41,7 @@ runs:
       shell: bash
       id: install_cargo_mutants
       run: |
-        cargo install --git https://github.com/ASuciuX/cargo-mutants --branch feat/variable-test-timeout cargo-mutants # v24.2.0 - with test timeout multiplier implementation
+        cargo install --version 24.2.1 cargo-mutants --locked # v24.2.1
 
     - name: Relative diff
       id: relative_diff

--- a/stacks-core/mutation-testing/pr-differences/action.yml
+++ b/stacks-core/mutation-testing/pr-differences/action.yml
@@ -39,7 +39,7 @@ runs:
       id: install_cargo_mutants
       shell: bash
       run: |
-        cargo install --git https://github.com/ASuciuX/cargo-mutants --branch feat/variable-test-timeout cargo-mutants # v24.2.0 - with test timeout multiplier implementation
+        cargo install --version 24.2.1 cargo-mutants --locked # v24.2.1
 
     - uses: taiki-e/install-action@ac89944b5b150d78567ab6c02badfbe48b0b55aa # v2.20.16
       name: Install cargo-nextest


### PR DESCRIPTION
Cargo mutants installation is failing due to unresolved imports (see https://github.com/stacks-network/stacks-core/actions/runs/8264747098/job/22608984060?pr=4530#step:2:1705). I've updated the installation to be from the official repository (previously was on fork, but now those changes are merged), and to include `--locked` flag (`cargo install cargo-mutants` fails without this flag). The compilation of the `cargo-mutants` now works with these updates.