### PR TITLE
Update Used Actions Versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ jobs:
       ## Setup docker buildx
       - name: Set up Docker Buildx
         id: docker_buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+        uses: docker/setup-buildx-action@2b51285047da1547ffb1b2203d8be4c0af6b1f20 # v3.2.0
 ```
 
 Which uses [this commit](https://github.com/docker/setup-buildx-action/commit/f95db51fddba0c2d1ec667646a06c2ce06100226)

--- a/codecov/action.yml
+++ b/codecov/action.yml
@@ -55,9 +55,9 @@ runs:
     ##   - use wretry action, to retry on a failed upload
     - name: Upload Code Coverage
       id: code_coverage
-      uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
+      uses: Wandalen/wretry.action@1a10d4835a1506f513ad8e7488aeb474ab20055c # v1.4.10
       with:
-        action: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+        action: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab # v4.1.0
         with: |
           files: ${{ inputs.filename }}
           name: ${{ inputs.test-name }}

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -56,7 +56,7 @@ runs:
     ## Setup docker buildx
     - name: Set up Docker Buildx
       id: docker_buildx
-      uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+      uses: docker/setup-buildx-action@2b51285047da1547ffb1b2203d8be4c0af6b1f20 # v3.2.0
 
     ## Login to dockerhub
     - name: Login to DockerHub
@@ -64,7 +64,7 @@ runs:
         inputs.username != '' &&
         inputs.password != ''
       id: docker_login
-      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+      uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
       with:
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}

--- a/generate-checksum/README.md
+++ b/generate-checksum/README.md
@@ -7,8 +7,9 @@ Generates a 512-bit `sha` hash for each file downloaded from artifacts.
 ### Inputs
 
 | Input | Description | Required | Default |
-| ------------------------------- | ----------------------------------------------------- | ------------------------- | ------------------------- |
-| `hashfile_name` | The name of the generated checksum file | false | "CHECKSUMS.txt" |
+| --------------- | ---------------------------------------------------------------------- | ------- | --------------- |
+| `hashfile_name` | The name of the generated checksum file                                | `false` | `CHECKSUMS.txt` |
+| `artifact_name` | Download artifacts starting with this name (defaults to all artifacts) | `false` |       `*`       |
 
 ## Usage
 
@@ -23,4 +24,7 @@ jobs:
       - name: Generate Checksum
         id: generate_checksum
         uses: stacks-network/actions/generate-checksum@main
+        with:
+          hashfile_name: "HASHES.txt"
+          artifact_name: "release-*"
 ```

--- a/generate-checksum/action.yml
+++ b/generate-checksum/action.yml
@@ -13,7 +13,7 @@ runs:
     ## Downloads the artifacts built in `create-source-binary.yml`
     - name: Download Artifacts
       id: download_artifacts
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
       with:
         name: artifact
         path: release

--- a/generate-checksum/action.yml
+++ b/generate-checksum/action.yml
@@ -13,7 +13,7 @@ runs:
     ## Downloads the artifacts built in `create-source-binary.yml`
     - name: Download Artifacts
       id: download_artifacts
-      uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: artifact
         path: release

--- a/generate-checksum/action.yml
+++ b/generate-checksum/action.yml
@@ -19,7 +19,8 @@ runs:
       id: download_artifacts
       uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
       with:
-        name: ${{ inputs.artifact_name }}
+        pattern: ${{ inputs.artifact_name }}
+        merge-multiple: 'true'
         path: artifacts
 
     ## Generate a checksums file

--- a/generate-checksum/action.yml
+++ b/generate-checksum/action.yml
@@ -6,19 +6,23 @@ inputs:
     description: "The name of the generated checksum file"
     required: false
     default: "CHECKSUMS.txt"
+  artifact_name:
+    description: "Download artifacts starting with this name"
+    required: false
+    default: "*"
 
 runs:
   using: "composite"
   steps:
-    ## Downloads the artifacts built in `create-source-binary.yml`
+    ## Downloads the artifacts from the workflow starting with 'artifact_name' input
     - name: Download Artifacts
       id: download_artifacts
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
       with:
-        name: artifact
-        path: release
+        name: ${{ inputs.artifact_name }}
+        path: artifacts
 
-    ## Generate a checksums file to be added to the release page
+    ## Generate a checksums file
     - name: Generate Checksums
       id: generate_checksum
       shell: bash
@@ -30,7 +34,7 @@ runs:
         fi
 
         # Generate the hashes and exit if the variable is empty
-        shasum="$(sha512sum release/*)"
+        shasum="$(sha512sum artifacts/*)"
         if [[ -z "$shasum" ]]; then
           echo "Checksum could not be generated!";
           exit 1;

--- a/openapi/action.yml
+++ b/openapi/action.yml
@@ -39,7 +39,7 @@ runs:
     ## Upload the html file artifact
     - name: Upload bundled html
       id: upload_html_artifact
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:
         name: open-api-bundle
         path: |

--- a/openapi/action.yml
+++ b/openapi/action.yml
@@ -39,7 +39,7 @@ runs:
     ## Upload the html file artifact
     - name: Upload bundled html
       id: upload_html_artifact
-      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: open-api-bundle
         path: |

--- a/openapi/action.yml
+++ b/openapi/action.yml
@@ -39,7 +39,7 @@ runs:
     ## Upload the html file artifact
     - name: Upload bundled html
       id: upload_html_artifact
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:
         name: open-api-bundle
         path: |

--- a/stacks-core/cache/bitcoin/action.yml
+++ b/stacks-core/cache/bitcoin/action.yml
@@ -43,7 +43,7 @@ runs:
       if: |
         inputs.action == 'check' ||
         inputs.action == 'save'
-      uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+      uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
       id: check_cache
       with:
         lookup-only: true
@@ -56,9 +56,9 @@ runs:
       if: |
         inputs.action == 'restore'
       id: restore_cache
-      uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
+      uses: Wandalen/wretry.action@1a10d4835a1506f513ad8e7488aeb474ab20055c # v1.4.10
       with:
-        action: actions/cache/restore@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+        action: actions/cache/restore@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with: |
           fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
           path: ~/bitcoin
@@ -84,9 +84,9 @@ runs:
         inputs.action == 'save' &&
         steps.check_cache.outputs.cache-hit != 'true'
       id: save_cache
-      uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
+      uses: Wandalen/wretry.action@1a10d4835a1506f513ad8e7488aeb474ab20055c # v1.4.10
       with:
-        action: actions/cache/save@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+        action: actions/cache/save@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with: |
           path: ~/bitcoin
           key: ${{ inputs.cache-key }}-${{ inputs.btc-version }}

--- a/stacks-core/cache/build-cache/action.yml
+++ b/stacks-core/cache/build-cache/action.yml
@@ -44,7 +44,7 @@ runs:
         steps.check_test_archive_cache.outputs.cache-hit != 'true' ||
         steps.check_genesis_test_archive_cache.outputs.cache-hit != 'true'
       id: setup_rust_toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@f3c84ee10bf5a86e7a5d607d487bf17d57670965 # v1.5.0
+      uses: actions-rust-lang/setup-rust-toolchain@b113a30d27a8e59c969077c0a0168cc13dab5ffc # v1.8.0
       with:
         toolchain: stable
         components: llvm-tools-preview

--- a/stacks-core/cache/cargo/action.yml
+++ b/stacks-core/cache/cargo/action.yml
@@ -39,7 +39,7 @@ runs:
       if: |
         inputs.action == 'check' ||
         inputs.action == 'save'
-      uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+      uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
       id: check_cache
       with:
         lookup-only: true
@@ -56,9 +56,9 @@ runs:
       if: |
         inputs.action == 'restore'
       id: restore_cache
-      uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
+      uses: Wandalen/wretry.action@1a10d4835a1506f513ad8e7488aeb474ab20055c # v1.4.10
       with:
-        action: actions/cache/restore@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+        action: actions/cache/restore@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with: |
           fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
           path: |
@@ -77,7 +77,7 @@ runs:
         inputs.action == 'save' &&
         steps.check_cache.outputs.cache-hit != 'true'
       id: install_nextest
-      uses: taiki-e/install-action@ac89944b5b150d78567ab6c02badfbe48b0b55aa # v2.20.16
+      uses: taiki-e/install-action@ffad14352befc011a07601bbf501b672acbc18e6 # v2.29.0
       with:
         tool: nextest # can be versioned, ex: tool@1.1.1.1
 
@@ -88,7 +88,7 @@ runs:
         inputs.action == 'save' &&
         steps.check_cache.outputs.cache-hit != 'true'
       id: install_grcov
-      uses: taiki-e/install-action@ac89944b5b150d78567ab6c02badfbe48b0b55aa # v2.20.16
+      uses: taiki-e/install-action@ffad14352befc011a07601bbf501b672acbc18e6 # v2.29.0
       with:
         tool: grcov # can be versioned, ex: tool@1.1.1.1
 
@@ -98,9 +98,9 @@ runs:
         inputs.action == 'save' &&
         steps.check_cache.outputs.cache-hit != 'true'
       id: save_cache
-      uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
+      uses: Wandalen/wretry.action@1a10d4835a1506f513ad8e7488aeb474ab20055c # v1.4.10
       with:
-        action: actions/cache/save@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+        action: actions/cache/save@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with: |
           path: |
             ~/.cargo/bin/

--- a/stacks-core/cache/genesis-test-archive/action.yml
+++ b/stacks-core/cache/genesis-test-archive/action.yml
@@ -39,7 +39,7 @@ runs:
       if: |
         inputs.action == 'check' ||
         inputs.action == 'save'
-      uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+      uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
       id: check_cache
       with:
         lookup-only: true
@@ -52,9 +52,9 @@ runs:
       if: |
         inputs.action == 'restore'
       id: restore_cache
-      uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
+      uses: Wandalen/wretry.action@1a10d4835a1506f513ad8e7488aeb474ab20055c # v1.4.10
       with:
-        action: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        action: actions/cache/restore@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with: |
           fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
           path: ~/genesis_archive.tar.zst
@@ -69,9 +69,9 @@ runs:
         inputs.action == 'save' &&
         steps.check_cache.outputs.cache-hit != 'true'
       id: save_cache
-      uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
+      uses: Wandalen/wretry.action@1a10d4835a1506f513ad8e7488aeb474ab20055c # v1.4.10
       with:
-        action: actions/cache/save@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+        action: actions/cache/save@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with: |
           path: ~/genesis_archive.tar.zst
           key: ${{ inputs.cache-key }}

--- a/stacks-core/cache/target/action.yml
+++ b/stacks-core/cache/target/action.yml
@@ -38,7 +38,7 @@ runs:
     - name: Check Cache
       if: |
         inputs.action == 'check'
-      uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+      uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
       id: check_cache
       with:
         lookup-only: true
@@ -51,9 +51,9 @@ runs:
       if: |
         inputs.action == 'restore'
       id: restore_cache
-      uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
+      uses: Wandalen/wretry.action@1a10d4835a1506f513ad8e7488aeb474ab20055c # v1.4.10
       with:
-        action: actions/cache/restore@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+        action: actions/cache/restore@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with: |
           fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
           path: ./target
@@ -67,9 +67,9 @@ runs:
       if: |
         inputs.action == 'save'
       id: save_cache
-      uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
+      uses: Wandalen/wretry.action@1a10d4835a1506f513ad8e7488aeb474ab20055c # v1.4.10
       with:
-        action: actions/cache/save@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+        action: actions/cache/save@ab5e6d0c87105b4c9c2047343972218f562e4319 #v4.0.1
         with: |
           path: ./target
           key: ${{ inputs.cache-key }}

--- a/stacks-core/cache/test-archive/action.yml
+++ b/stacks-core/cache/test-archive/action.yml
@@ -39,7 +39,7 @@ runs:
       if: |
         inputs.action == 'check' ||
         inputs.action == 'save'
-      uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+      uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 #v4.0.1
       id: check_cache
       with:
         lookup-only: true
@@ -52,9 +52,9 @@ runs:
       if: |
         inputs.action == 'restore'
       id: restore_cache
-      uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
+      uses: Wandalen/wretry.action@1a10d4835a1506f513ad8e7488aeb474ab20055c #v1.4.10
       with:
-        action: actions/cache/restore@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+        action: actions/cache/restore@ab5e6d0c87105b4c9c2047343972218f562e4319 #v4.0.1
         with: |
           fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
           path: ~/test_archive.tar.zst
@@ -69,9 +69,9 @@ runs:
         inputs.action == 'save' &&
         steps.check_cache.outputs.cache-hit != 'true'
       id: save_cache
-      uses: Wandalen/wretry.action@a163f62ae554a8f3cbe27b23db15b60c0ae2e93c # v1.3.0
+      uses: Wandalen/wretry.action@1a10d4835a1506f513ad8e7488aeb474ab20055c #v1.4.10
       with:
-        action: actions/cache/save@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+        action: actions/cache/save@ab5e6d0c87105b4c9c2047343972218f562e4319 #v4.0.1
         with: |
           path: ~/test_archive.tar.zst
           key: ${{ inputs.cache-key }}

--- a/stacks-core/create-source-binary/action.yml
+++ b/stacks-core/create-source-binary/action.yml
@@ -67,7 +67,7 @@ runs:
     ## Build the binaries using defined dockerfiles
     - name: Build Binary (${{ inputs.arch }}_${{ inputs.cpu }})
       id: build_binaries
-      uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # 5.0.0
+      uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # 5.3.0
       with:
         file: ${{ github.action_path }}/build-scripts/${{ env.DOCKERFILE }}
         outputs: type=local,dest=./release/${{ inputs.arch }}
@@ -88,6 +88,6 @@ runs:
     ## Upload the binary artifact to the github action (used in `github-release.yml` to create a release)
     - name: Upload artifact
       id: upload_artifact
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:
         path: ${{ env.ZIPFILE }}.zip

--- a/stacks-core/create-source-binary/action.yml
+++ b/stacks-core/create-source-binary/action.yml
@@ -88,6 +88,6 @@ runs:
     ## Upload the binary artifact to the github action (used in `github-release.yml` to create a release)
     - name: Upload artifact
       id: upload_artifact
-      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         path: ${{ env.ZIPFILE }}.zip

--- a/stacks-core/create-source-binary/action.yml
+++ b/stacks-core/create-source-binary/action.yml
@@ -88,6 +88,7 @@ runs:
     ## Upload the binary artifact to the github action (used in `github-release.yml` to create a release)
     - name: Upload artifact
       id: upload_artifact
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:
+        name: ${{ inputs.tag }}-${{ env.ZIPFILE }}
         path: ${{ env.ZIPFILE }}.zip

--- a/stacks-core/mutation-testing/output-pr-mutants/action.yml
+++ b/stacks-core/mutation-testing/output-pr-mutants/action.yml
@@ -33,7 +33,7 @@ runs:
   steps:
     - name: Download artifacts
       id: download_artifacts
-      uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+      uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
 
     - name: Append output from shards
       id: append_mutant_outcomes

--- a/stacks-core/mutation-testing/pr-differences/action.yml
+++ b/stacks-core/mutation-testing/pr-differences/action.yml
@@ -41,7 +41,7 @@ runs:
       run: |
         cargo install --version 24.2.1 cargo-mutants --locked # v24.2.1
 
-    - uses: taiki-e/install-action@ac89944b5b150d78567ab6c02badfbe48b0b55aa # v2.20.16
+    - uses: taiki-e/install-action@ffad14352befc011a07601bbf501b672acbc18e6 # v2.29.0
       name: Install cargo-nextest
       id: install_cargo_nextest
       with:
@@ -254,7 +254,7 @@ runs:
 
     - name: Upload artifact
       id: upload_artifact
-      uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334595 # v4.1.0
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:
         name: mutants-shard-${{ inputs.package }}-${{ inputs.shard }}
         path: mutants-shard-${{ inputs.package }}-${{ inputs.shard }}

--- a/stacks-core/testenv/action.yml
+++ b/stacks-core/testenv/action.yml
@@ -30,7 +30,7 @@ runs:
     ## Install rust toolchain (llvm-tools-preview)
     - name: Setup Rust Toolchain
       id: setup_rust_toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@f3c84ee10bf5a86e7a5d607d487bf17d57670965 # v1.5.0
+      uses: actions-rust-lang/setup-rust-toolchain@b113a30d27a8e59c969077c0a0168cc13dab5ffc # v1.8.0
       with:
         toolchain: stable
         components: llvm-tools-preview


### PR DESCRIPTION
## Description

Updated all marketplace actions to their latest version - the node version that some of them were using was `Node.js 16`, which is deprecated and comes up as a warning in the runners, `Node.js 20` being the one used in the latest versions of these actions.

**Notes:**
- `upload-artifact` action had a change from `v3` to `v4` and the workflow is unable to append to the initial artifact when uploading with the same name, and I had to specify different names in this cases (`create-source-binary` action).
- Added input for artifact name (defaults to all artifacts) to `generate-checksum` composite action, because previously it was downloading an artifact with hardcoded name (`artifact`) - which no longer exists.

### Important Note
Due to the way `download-artifact` works inside `generate-checksum`, merging this PR would require either:
- A hotfix in `github-release` ([stacks-core@master](https://github.com/stacks-network/stacks-core/blob/master/.github/workflows/github-release.yml#L60-L62)):
  ```diff
    - name: Generate Checksums
      id: generate_checksum
      uses: stacks-network/actions/generate-checksum@main
  +   with:
  +     artifact_name: ${{ inputs.tag }}-*
  ```
- Changing the artifact name in [create-source-binary](https://github.com/BowTiedDevOps/actions/blob/feat/update-actions-versions/stacks-core/create-source-binary/action.yml#L93) to the commit hash that triggered the workflow (since tag is not available in the `generate-checksum` action) + harcoding the pattern in [generate-checksum](https://github.com/BowTiedDevOps/actions/blob/feat/update-actions-versions/generate-checksum/action.yml#L22) to the commit hash - which would restrict the use of `generate-checksum` composite in other cases since it only downloads artifacts whose names start with the commit hash that triggered the workflow. 

Downloading all artifacts is not an option because there is also an artifact called `open-api-bundle` for which we do not want to generate checksums.

## Example Runs
In these runs, the first approach from `Important Note` was taken - `A hotfix in github-release (stacks-core@master)`.

For the `CI Tagged Release Flow` example, you can still see `Node.js 16` warnings because internal composite calls are made to `stacks-network/actions`, which does not implement these changes. The following dotted examples are run on the source branch for this PR.

- CI Tagged Release Flow (Cancelled doe to `Code Coverage` timeout on `Epoch Tests`): https://github.com/BowTiedDevOps/stacks-core/actions/runs/8332074791
- Docker Image (Source): https://github.com/BowTiedDevOps/stacks-core/actions/runs/8332070780
- Workflow Cleanup: https://github.com/BowTiedDevOps/stacks-core/actions/runs/8332070161

Running CI Tagged Release with internal composite calls made to the same branch as where these changes are implemented (similarly to how it will be run after the merge): https://github.com/BowTiedDevOps/stacks-core/actions/runs/8332709186