### PR TITLE
Run Release Builds for all Archs and Cpus

### DIFF
--- a/stacks-core/create-source-binary/action.yml
+++ b/stacks-core/create-source-binary/action.yml
@@ -22,17 +22,11 @@ runs:
     ## Setup Docker for the builds
     - name: Docker setup
       id: docker_setup
-      if: |
-        inputs.arch == 'linux-glibc' &&
-        inputs.cpu != 'armv7'
       uses: stacks-network/actions/docker@main
 
     ## Set env vars based on the type of arch build
     - name: Set local env vars
       id: set_env
-      if: |
-        inputs.arch == 'linux-glibc' &&
-        inputs.cpu != 'armv7'
       shell: bash
       run: |
         case ${{ inputs.cpu }} in
@@ -73,9 +67,6 @@ runs:
     ## Build the binaries using defined dockerfiles
     - name: Build Binary (${{ inputs.arch }}_${{ inputs.cpu }})
       id: build_binaries
-      if: |
-        inputs.arch == 'linux-glibc' &&
-        inputs.cpu != 'armv7'
       uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # 5.0.0
       with:
         file: ${{ github.action_path }}/build-scripts/${{ env.DOCKERFILE }}
@@ -90,9 +81,6 @@ runs:
     ## Compress the binary artifact
     - name: Compress artifact
       id: compress_artifact
-      if: |
-        inputs.arch == 'linux-glibc' &&
-        inputs.cpu != 'armv7'
       shell: bash
       run: |
         zip --junk-paths ${{ env.ZIPFILE }} ./release/${{ inputs.arch }}/*


### PR DESCRIPTION
Revert Jesse's changes so the release builds work for all architectures and cpus.