### PR TITLE
build all binaries by default

### DIFF
--- a/stacks-core/create-source-binary/action.yml
+++ b/stacks-core/create-source-binary/action.yml
@@ -22,17 +22,11 @@ runs:
     ## Setup Docker for the builds
     - name: Docker setup
       id: docker_setup
-      if: |
-        inputs.arch == 'linux-glibc' &&
-        inputs.cpu != 'armv7'
       uses: stacks-network/actions/docker@main
 
     ## Set env vars based on the type of arch build
     - name: Set local env vars
       id: set_env
-      if: |
-        inputs.arch == 'linux-glibc' &&
-        inputs.cpu != 'armv7'
       shell: bash
       run: |
         case ${{ inputs.cpu }} in
@@ -73,9 +67,6 @@ runs:
     ## Build the binaries using defined dockerfiles
     - name: Build Binary (${{ inputs.arch }}_${{ inputs.cpu }})
       id: build_binaries
-      if: |
-        inputs.arch == 'linux-glibc' &&
-        inputs.cpu != 'armv7'
       uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # 5.0.0
       with:
         file: ${{ github.action_path }}/build-scripts/${{ env.DOCKERFILE }}
@@ -90,9 +81,6 @@ runs:
     ## Compress the binary artifact
     - name: Compress artifact
       id: compress_artifact
-      if: |
-        inputs.arch == 'linux-glibc' &&
-        inputs.cpu != 'armv7'
       shell: bash
       run: |
         zip --junk-paths ${{ env.ZIPFILE }} ./release/${{ inputs.arch }}/*

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-arm64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-arm64
@@ -11,16 +11,16 @@ COPY . .
 
 RUN apt-get update && apt-get install -y git gcc-aarch64-linux-gnu libclang-dev llvm
 
-# Run all the build steps in ramdisk in an attempt to speed things up
+# Run all the build steps in ramdisk in an attempt to improve build time
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
     && CC=aarch64-linux-gnu-gcc \
     CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
-    cargo build --features monitoring_prom,slog_json,portable --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli --bin stacks-signer \
+    cargo build --features monitoring_prom,slog_json,portable --release --workspace --target ${TARGET} \
     && mkdir -p /out \
-    && cp -R ${BUILD_DIR}/target/${TARGET}/release/. /out
+    && find ${BUILD_DIR}/target/${TARGET}/release/ -maxdepth 1 -executable -type f | xargs cp -at /out/
 
 FROM scratch AS export-stage
-COPY --from=build /out/stacks-inspect /out/blockstack-cli /out/clarity-cli /out/stacks-node /out/stacks-signer /
+COPY --from=build /out/* /

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-armv7
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-armv7
@@ -11,16 +11,16 @@ COPY . .
 
 RUN apt-get update && apt-get install -y git gcc-arm-linux-gnueabihf libclang-dev llvm
 
-# Run all the build steps in ramdisk in an attempt to speed things up
+# Run all the build steps in ramdisk in an attempt to improve build time
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
     && CC=arm-linux-gnueabihf-gcc \
     CC_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc \
     CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
-    cargo build --features monitoring_prom,slog_json,portable --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
+    cargo build --features monitoring_prom,slog_json,portable --release --workspace --target ${TARGET} \
     && mkdir -p /out \
-    && cp -R ${BUILD_DIR}/target/${TARGET}/release/. /out
+    && find ${BUILD_DIR}/target/${TARGET}/release/ -maxdepth 1 -executable -type f | xargs cp -at /out/
 
 FROM scratch AS export-stage
-COPY --from=build /out/stacks-inspect /out/blockstack-cli /out/clarity-cli /out/stacks-node /
+COPY --from=build /out/* /

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-x64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-x64
@@ -14,13 +14,13 @@ COPY . .
 
 RUN apt-get update && apt-get install -y git libclang-dev llvm
 
-# Run all the build steps in ramdisk in an attempt to speed things up
+# Run all the build steps in ramdisk in an attempt to improve build time
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
-    && cargo build --features monitoring_prom,slog_json,portable --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli --bin stacks-signer \
+    && cargo build --features monitoring_prom,slog_json,portable --release --workspace --target ${TARGET} \
     && mkdir -p /out \
-    && cp -R ${BUILD_DIR}/target/${TARGET}/release/. /out
+    && find ${BUILD_DIR}/target/${TARGET}/release/ -maxdepth 1 -executable -type f | xargs cp -at /out/
 
 FROM scratch AS export-stage
-COPY --from=build /out/stacks-inspect /out/blockstack-cli /out/clarity-cli /out/stacks-node /out/stacks-signer /
+COPY --from=build /out/* /

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-musl-arm64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-musl-arm64
@@ -9,13 +9,13 @@ WORKDIR /src
 
 COPY . .
 
-# Run all the build steps in ramdisk in an attempt to speed things up
+# Run all the build steps in ramdisk in an attempt to improve build time
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
-    && cargo build --features monitoring_prom,slog_json,portable --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
+    && cargo build --features monitoring_prom,slog_json,portable --release --workspace --target ${TARGET} \
     && mkdir -p /out \
-    && cp -R ${BUILD_DIR}/target/${TARGET}/release/. /out
+    && find ${BUILD_DIR}/target/${TARGET}/release/ -maxdepth 1 -executable -type f | xargs cp -at /out/
 
 FROM scratch AS export-stage
-COPY --from=build /out/stacks-inspect /out/blockstack-cli /out/clarity-cli /out/stacks-node /
+COPY --from=build /out/* /

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-musl-armv7
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-musl-armv7
@@ -9,13 +9,13 @@ WORKDIR /src
 
 COPY . .
 
-# Run all the build steps in ramdisk in an attempt to speed things up
+# Run all the build steps in ramdisk in an attempt to improve build time
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
-    && cargo build --features monitoring_prom,slog_json,portable --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
+    && cargo build --features monitoring_prom,slog_json,portable --release --workspace --target ${TARGET} \
     && mkdir -p /out \
-    && cp -R ${BUILD_DIR}/target/${TARGET}/release/. /out
+    && find ${BUILD_DIR}/target/${TARGET}/release/ -maxdepth 1 -executable -type f | xargs cp -at /out/
 
 FROM scratch AS export-stage
-COPY --from=build /out/stacks-inspect /out/blockstack-cli /out/clarity-cli /out/stacks-node /
+COPY --from=build /out/* /

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-musl-x64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-musl-x64
@@ -13,14 +13,13 @@ COPY . .
 
 RUN apk update && apk add git musl-dev make
 
-# Run all the build steps in ramdisk in an attempt to speed things up
+# Run all the build steps in ramdisk in an attempt to improve build time
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
-    && cargo build --features monitoring_prom,slog_json,portable --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
+    && cargo build --features monitoring_prom,slog_json,portable --release --workspace --target ${TARGET} \
     && mkdir -p /out \
-    && cp -R ${BUILD_DIR}/target/${TARGET}/release/. /out
+    && find ${BUILD_DIR}/target/${TARGET}/release/ -maxdepth 1 -executable -type f | xargs cp -at /out/
 
 FROM scratch AS export-stage
-COPY --from=build /out/stacks-inspect /out/blockstack-cli /out/clarity-cli /out/stacks-node /
-
+COPY --from=build /out/* /

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.macos-arm64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.macos-arm64
@@ -1,3 +1,6 @@
+#######################################################################################
+##      ** Note that this build will not include the `stacks-signer` binary **       ##
+#######################################################################################
 FROM rust:bullseye as build
 
 ARG STACKS_NODE_VERSION="No Version Info"
@@ -16,14 +19,14 @@ RUN apt-get update && apt-get install -y clang zstd
 RUN wget -nc -O /tmp/osxcross.tar.zst ${OSXCROSS} \
     && mkdir -p /opt/osxcross && tar -xaf /tmp/osxcross.tar.zst -C /opt/osxcross
 
-# Run all the build steps in ramdisk in an attempt to speed things up
+# Run all the build steps in ramdisk in an attempt to improve build time
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
     && . /opt/osxcross/env-macos-aarch64 \
     && cargo build --features monitoring_prom,slog_json,portable --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
     && mkdir -p /out \
-    && cp -R ${BUILD_DIR}/target/${TARGET}/release/. /out
+    && find ${BUILD_DIR}/target/${TARGET}/release/ -maxdepth 1 -executable -type f | xargs cp -at /out/
 
 FROM scratch AS export-stage
-COPY --from=build /out/stacks-inspect /out/blockstack-cli /out/clarity-cli /out/stacks-node /
+COPY --from=build /out/* /

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.macos-x64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.macos-x64
@@ -18,14 +18,14 @@ RUN apt-get update && apt-get install -y clang zstd
 RUN wget -nc -O /tmp/osxcross.tar.zst ${OSXCROSS} \
     && mkdir -p /opt/osxcross && tar -xaf /tmp/osxcross.tar.zst -C /opt/osxcross
 
-# Run all the build steps in ramdisk in an attempt to speed things up
+# Run all the build steps in ramdisk in an attempt to improve build time
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
     && . /opt/osxcross/env-macos-x86_64 \
-    && cargo build --features monitoring_prom,slog_json,portable --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
+    && cargo build --features monitoring_prom,slog_json,portable --release --workspace --target ${TARGET} \
     && mkdir -p /out \
-    && cp -R ${BUILD_DIR}/target/${TARGET}/release/. /out
+    && find ${BUILD_DIR}/target/${TARGET}/release/ -maxdepth 1 -executable -type f | xargs cp -at /out/
 
 FROM scratch AS export-stage
-COPY --from=build /out/stacks-inspect /out/blockstack-cli /out/clarity-cli /out/stacks-node /
+COPY --from=build /out/* /

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.windows-x64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.windows-x64
@@ -13,15 +13,15 @@ COPY . .
 
 RUN apt-get update && apt-get install -y git gcc-mingw-w64-x86-64 libclang-dev
 
-# Run all the build steps in ramdisk in an attempt to speed things up
+# Run all the build steps in ramdisk in an attempt to improve build time
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
     && CC_x86_64_pc_windows_gnu=x86_64-w64-mingw32-gcc \
     CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=x86_64-w64-mingw32-gcc \
-    cargo build --features monitoring_prom,slog_json,portable --release --workspace --target ${TARGET} --bin stacks-node --bin stacks-inspect --bin clarity-cli --bin blockstack-cli \
+    cargo build --features monitoring_prom,slog_json,portable --release --workspace --target ${TARGET} \
     && mkdir -p /out \
-    && cp -R ${BUILD_DIR}/target/${TARGET}/release/. /out
+    && find ${BUILD_DIR}/target/${TARGET}/release/ -maxdepth 1 -executable -type f | xargs cp -at /out/
 
 FROM scratch AS export-stage
-COPY --from=build /out/stacks-inspect.exe /out/blockstack-cli.exe /out/clarity-cli.exe /out/stacks-node.exe /
+COPY --from=build /out/* /


### PR DESCRIPTION
ref: #20 
changes  the cargo build line in dockerfiles to build all binaries, then uses `find` to copy just the executable binaries . 

ex:
```
...
    && find ${BUILD_DIR}/target/${TARGET}/release/ -maxdepth 1 -executable -type f | xargs cp -at /out/

FROM scratch AS export-stage
COPY --from=build /out/* /
```

this results in easier modifications if we add/remove binaries. 

the one outlier is the macos-arm64 build file, since it cannot currently build the stacks-signer binary when cross-compiling. 
ex workflow:
https://github.com/wileyj/stacks-blockchain/actions/runs/8530297851