### PR TITLE
Show only file name in checksum, setup rustfmt in composite

### DIFF
--- a/generate-checksum/action.yml
+++ b/generate-checksum/action.yml
@@ -42,7 +42,7 @@ runs:
           exit 1;
         fi
 
-        shasum="$(sha512sum ./*)"
+        shasum="$(sha512sum *)"
         if [[ -z "$shasum" ]]; then
           echo "Checksum could not be generated!";
           exit 1;

--- a/generate-checksum/action.yml
+++ b/generate-checksum/action.yml
@@ -35,6 +35,7 @@ runs:
         fi
 
         # Generate the hashes and exit if the variable is empty
+        cd release
         shasum="$(sha512sum release/*)"
         if [[ -z "$shasum" ]]; then
           echo "Checksum could not be generated!";
@@ -43,5 +44,5 @@ runs:
 
         echo "Generated checksums:"
         echo "$shasum"
-        echo "$shasum" > "${{ inputs.hashfile_name }}";
+        echo "$shasum" > "../${{ inputs.hashfile_name }}";
         exit 0;

--- a/generate-checksum/action.yml
+++ b/generate-checksum/action.yml
@@ -35,8 +35,14 @@ runs:
         fi
 
         # Generate the hashes and exit if the variable is empty
-        cd release
-        shasum="$(sha512sum release/*)"
+        if [ -d release ]; then
+          cd release
+        else
+          echo "Artifact directory does not exist!"
+          exit 1;
+        fi
+
+        shasum="$(sha512sum ./*)"
         if [[ -z "$shasum" ]]; then
           echo "Checksum could not be generated!";
           exit 1;

--- a/rustfmt/action.yml
+++ b/rustfmt/action.yml
@@ -19,6 +19,17 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Checkout the latest code
+      id: git_checkout
+      uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+
+    - name: Setup Rust Toolchain
+      id: setup_rust_toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@b113a30d27a8e59c969077c0a0168cc13dab5ffc # v1.8.0
+      with:
+        components: rustfmt
+        cache: false
+
     - name: Rustfmt Job Summary
       shell: bash
       run: |


### PR DESCRIPTION
## Description

This PR addresses 2 small but nice-to-have changes:
- The checksum file generated has the path `release/<file_name>`. This has changed so it only includes the file_name (i.e. `<file_name>`), so the file is ready to be copy-pasted.
- Setting the rust toolchain and checkouting the code inside composite actions for easier code maintenance, addressed in https://github.com/stacks-network/stacks-core/issues/4794.

~~Example run: https://github.com/BowTiedDevOps/stacks-core/actions/runs/9087322966~~ (failed due to shutdown signal)
Example run: https://github.com/BowTiedDevOps/stacks-core/actions/runs/9087482799