### PR TITLE
fix(rustfmt): Read `rustfmt` alias from `.cargo/config` or `.cargo/config.toml`

### DIFF
--- a/rustfmt/README.md
+++ b/rustfmt/README.md
@@ -11,10 +11,10 @@ All inputs are optional.
 If a [toolchain file](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) (i.e., `rust-toolchain` or `rust-toolchain.toml`) is found in the root of the repository, it takes precedence.
 All input values are ignored if a toolchain file exists.
 
-| Name            | Description                                                              | Default      |
-| --------------- | ------------------------------------------------------------------------ | ------------ |
-| `manifest-path` | Path to the `Cargo.toml` file, by default in the root of the repository. | `./Cargo.toml` |
-| `alias`         | The alias for cargo fmt (set in `.cargo/config`)                         | `fmt` |
+| Name            | Description                                                                | Default        |
+| --------------- | -------------------------------------------------------------------------- | -------------- |
+| `manifest-path` | Path to the `Cargo.toml` file, by default in the root of the repository.   | `./Cargo.toml` |
+| `alias`         | The alias for `cargo fmt` (set in `.cargo/config` or `.cargo/config.toml`) | `fmt`          |
 
 [`actions-rust-lang/setup-rust-toolchain`]: https://github.com/actions-rust-lang/setup-rust-toolchain
 [problem matcher]: https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md

--- a/rustfmt/action.yml
+++ b/rustfmt/action.yml
@@ -22,8 +22,21 @@ runs:
     - name: Rustfmt Job Summary
       shell: bash
       run: |
+        # Find Cargo config file
+        declare -a config_file_locations=(".cargo/config.toml" ".cargo/config")
+        config_file=""
+        for file in "${config_file_locations[@]}"; do
+          if [ -f "$file" ]; then
+            config_file="$file"
+            break
+          fi
+        done
+        if [ -z "$config_file" ]; then
+          echo "No config file found!";
+        fi
+
         # Split alias command's options
-        alias=$(grep -e "${{ inputs.alias }}.*=" .cargo/config | tr -d '"' | awk '/^${{ inputs.alias }}[[:space:]]*=/ {sub(/^${{ inputs.alias }}[[:space:]]*=[[:space:]]*/, ""); print; exit}')
+        alias=$(grep -e "${{ inputs.alias }}.*=" "$config_file" | tr -d '"' | awk '/^${{ inputs.alias }}[[:space:]]*=/ {sub(/^${{ inputs.alias }}[[:space:]]*=[[:space:]]*/, ""); print; exit}')
 
         before_empty_dashes=""
         after_empty_dashes=""

--- a/rustfmt/action.yml
+++ b/rustfmt/action.yml
@@ -33,6 +33,7 @@ runs:
         done
         if [ -z "$config_file" ]; then
           echo "No config file found!";
+          exit 1;
         fi
 
         # Split alias command's options
@@ -48,6 +49,7 @@ runs:
 
         if [[ "${args[0]}" != "fmt" && "${{ inputs.alias }}" != "fmt" ]]; then
           echo "The provided alias is invalid!";
+          exit 1;
         fi
 
         for arg in "${args[@]}"; do


### PR DESCRIPTION
## Description

Read `rustfmt` alias from either `.cargo/config` or `.cargo/config.toml` (prefer the latter)

Required for stacks-network/stacks-core#4799
