### PR TITLE
fix: run one test at a time

### DIFF
--- a/stacks-core/run-tests/action.yml
+++ b/stacks-core/run-tests/action.yml
@@ -45,4 +45,4 @@ runs:
           --fail-fast \
           --success-output ${{ inputs.success-output }} \
           --status-level ${{ inputs.status-level }} \
-          "${{ inputs.test-name }}"
+          -E "test(=${{ inputs.test-name }})"


### PR DESCRIPTION
The previous method matched any tests that include the test-name, not
just the exact match. This solves that problem using the `-E` flag to
specify the filterset to match exactly.