### PR TITLE
Add Modifications Required for Different Types of Releases

### DIFF
--- a/stacks-core/README.md
+++ b/stacks-core/README.md
@@ -7,3 +7,4 @@ Folder of composite actions for the [stacks blockchain](https://github.com/stack
 - [run-tests](./run-tests) - Run tests with [nextest](https://nexte.st)
 - [mutation-testing](./mutation-testing) - Run mutation testing
 - [create-source-binary](./create-source-binary) - Create the stacks-core binaries for release
+- [check-release](./check-release) - Check whether there is a node/signer release or not

--- a/stacks-core/check-release/README.md
+++ b/stacks-core/check-release/README.md
@@ -29,4 +29,6 @@ jobs:
       - name: Check Release
         id: check_release
         uses: stacks-network/actions/stacks-core/check-release@main
+        with:
+          tag: "release/2.5.0.0.5-rc6"
 ```

--- a/stacks-core/check-release/README.md
+++ b/stacks-core/check-release/README.md
@@ -1,0 +1,32 @@
+# Check Release action
+
+Checks whether the tag parsed as argument matches a stacks-node release, a stacks-signer release or no release at all, through regex patterns.
+
+## Documentation
+
+### Inputs
+| Input | Description | Required | Default |
+| ----- | ------------------------------------------- | ----- | -- |
+| `tag` | The branch name against which the step runs | false | "" |
+
+### Outputs
+| Output | Description |
+| ------------ | -------------------------------------------------------------- |
+|     `tag`    | The release tag, if there is one (empty otherwise).            |
+| `docker_tag` | The release tag for docker, if there is one (empty otherwise). |
+| `is_release` | True if the branch is a release one, false otherwise.          |
+
+## Usage
+
+```yaml
+name: Action
+on: pull-request
+jobs:
+  check-packages-and-shards:
+    name: Check Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Release
+        id: check_release
+        uses: stacks-network/actions/stacks-core/check-release@main
+```

--- a/stacks-core/check-release/action.yml
+++ b/stacks-core/check-release/action.yml
@@ -1,0 +1,66 @@
+## Composite action to check if the branch is a release tag or not
+name: Check Release
+
+inputs:
+  tag:
+    description: "The branch name against which the step runs"
+    required: false
+    default: ""
+
+outputs:
+  tag:
+    description: "The release tag, if there is one (empty otherwise)."
+    value: ${{ steps.check_release.outputs.tag }}
+  docker_tag:
+    description: "The release tag for docker, if there is one (empty otherwise)."
+    value: ${{ steps.check_release.outputs.docker_tag }}
+  is_release:
+    description: "True if the branch is a release one, false otherwise."
+    value: ${{ steps.check_release.outputs.is_release }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set Release Outputs
+      id: check_release
+      shell: bash
+      run: |
+        branch_name=${{ inputs.tag }}
+
+        stacks_core_version_regex="([0-9].[0-9].[0-9].[0-9].[0-9]+(-rc[0-9]+)?)"    # matches x.x.x.x.x || x.x.x.x.x-rcx
+        signer_version_regex="([0-9].[0-9].[0-9].[0-9].[0-9].[0-9]+(-rc[0-9]+)?)"   # matches x.x.x.x.x.x || x.x.x.x.x.x-rcx
+
+        stacks_core_regex_base="release/"
+        signer_regex_base="release/signer-"
+
+        stacks_core_regex="${stacks_core_regex_base}${stacks_core_version_regex}"
+        signer_regex="${signer_regex_base}${signer_version_regex}"
+
+        tag=""
+        docker_tag=""
+        is_release=false
+
+        if [[ "$branch_name" =~ ^${stacks_core_regex}$ || "$branch_name" =~ ^${signer_regex}$ ]]; then
+          tag=$(echo "$branch_name" | sed "s|^${stacks_core_regex_base}||g")
+          case ${branch_name} in
+            release/signer-[0-9]*)
+              docker_tag=$(echo "$branch_name" | sed "s|^${signer_regex_base}||g")
+              is_release=true
+              ;;
+            *)
+              docker_tag=${tag}
+              is_release=true
+              ;;
+          esac
+        fi
+
+        echo "branch name: $branch_name"
+        echo "tag: $tag"
+        echo "docker_tag: $docker_tag"
+        echo "is_release: $is_release"
+
+        echo "tag=$tag" >> "$GITHUB_OUTPUT"
+        echo "docker_tag=$docker_tag" >> "$GITHUB_OUTPUT"
+        echo "is_release=$is_release" >> "$GITHUB_OUTPUT"
+
+        exit 0

--- a/stacks-core/check-release/action.yml
+++ b/stacks-core/check-release/action.yml
@@ -54,11 +54,6 @@ runs:
           esac
         fi
 
-        echo "branch name: $branch_name"
-        echo "tag: $tag"
-        echo "docker_tag: $docker_tag"
-        echo "is_release: $is_release"
-
         echo "tag=$tag" >> "$GITHUB_OUTPUT"
         echo "docker_tag=$docker_tag" >> "$GITHUB_OUTPUT"
         echo "is_release=$is_release" >> "$GITHUB_OUTPUT"

--- a/stacks-core/create-source-binary/action.yml
+++ b/stacks-core/create-source-binary/action.yml
@@ -77,6 +77,7 @@ runs:
           TARGET_CPU=${{ env.TARGET_CPU }}
           GIT_BRANCH=${{ env.GITHUB_REF_SHORT }}
           GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
+          TAG=${{ inputs.tag }}
 
     ## Compress the binary artifact
     - name: Compress artifact

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-arm64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-arm64
@@ -5,6 +5,7 @@ ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 ARG BUILD_DIR=/build
 ARG TARGET=aarch64-unknown-linux-gnu
+ARG TAG="No Tag Info"
 WORKDIR /src
 
 COPY . .
@@ -15,10 +16,18 @@ RUN apt-get update && apt-get install -y git gcc-aarch64-linux-gnu libclang-dev 
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
+    && case "${TAG}" in \
+        signer-*) \
+            BUILD_ARG="--bin stacks-signer" \
+            ;; \
+        *) \
+            BUILD_ARG="" \
+            ;; \
+    esac \
     && CC=aarch64-linux-gnu-gcc \
     CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
-    cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} \
+    cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} ${BUILD_ARG} \
     && mkdir -p /out \
     && find ${BUILD_DIR}/target/${TARGET}/release/ -maxdepth 1 -executable -type f | xargs cp -at /out/
 

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-arm64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-arm64
@@ -5,7 +5,7 @@ ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 ARG BUILD_DIR=/build
 ARG TARGET=aarch64-unknown-linux-gnu
-ARG TAG="No Tag Info"
+ARG TAG
 WORKDIR /src
 
 COPY . .

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-armv7
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-armv7
@@ -5,6 +5,7 @@ ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 ARG BUILD_DIR=/build
 ARG TARGET=armv7-unknown-linux-gnueabihf
+ARG TAG="No Tag Info"
 WORKDIR /src
 
 COPY . .
@@ -15,10 +16,18 @@ RUN apt-get update && apt-get install -y git gcc-arm-linux-gnueabihf libclang-de
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
+    && case "${TAG}" in \
+        signer-*) \
+            BUILD_ARG="--bin stacks-signer" \
+            ;; \
+        *) \
+            BUILD_ARG="" \
+            ;; \
+    esac \
     && CC=arm-linux-gnueabihf-gcc \
     CC_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc \
     CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
-    cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} \
+    cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} ${BUILD_ARG} \
     && mkdir -p /out \
     && find ${BUILD_DIR}/target/${TARGET}/release/ -maxdepth 1 -executable -type f | xargs cp -at /out/
 

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-armv7
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-armv7
@@ -5,7 +5,7 @@ ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 ARG BUILD_DIR=/build
 ARG TARGET=armv7-unknown-linux-gnueabihf
-ARG TAG="No Tag Info"
+ARG TAG
 WORKDIR /src
 
 COPY . .

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-x64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-x64
@@ -8,7 +8,7 @@ ARG TARGET=x86_64-unknown-linux-gnu
 # Allow us to override the default `--target-cpu` for the given target triplet
 ARG TARGET_CPU
 ENV RUSTFLAGS="${TARGET_CPU:+${RUSTFLAGS} -Ctarget-cpu=${TARGET_CPU}}"
-ARG TAG="No Tag Info"
+ARG TAG
 WORKDIR /src
 
 COPY . .

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-x64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-glibc-x64
@@ -8,6 +8,7 @@ ARG TARGET=x86_64-unknown-linux-gnu
 # Allow us to override the default `--target-cpu` for the given target triplet
 ARG TARGET_CPU
 ENV RUSTFLAGS="${TARGET_CPU:+${RUSTFLAGS} -Ctarget-cpu=${TARGET_CPU}}"
+ARG TAG="No Tag Info"
 WORKDIR /src
 
 COPY . .
@@ -18,7 +19,15 @@ RUN apt-get update && apt-get install -y git libclang-dev llvm
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
-    && cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} \
+    && case "${TAG}" in \
+        signer-*) \
+            BUILD_ARG="--bin stacks-signer" \
+            ;; \
+        *) \
+            BUILD_ARG="" \
+            ;; \
+    esac \
+    && cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} ${BUILD_ARG} \
     && mkdir -p /out \
     && find ${BUILD_DIR}/target/${TARGET}/release/ -maxdepth 1 -executable -type f | xargs cp -at /out/
 

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-musl-arm64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-musl-arm64
@@ -5,7 +5,7 @@ ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 ARG BUILD_DIR=/build
 ARG TARGET=aarch64-unknown-linux-musl
-ARG TAG="No Tag Info"
+ARG TAG
 WORKDIR /src
 
 COPY . .

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-musl-arm64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-musl-arm64
@@ -5,6 +5,7 @@ ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 ARG BUILD_DIR=/build
 ARG TARGET=aarch64-unknown-linux-musl
+ARG TAG="No Tag Info"
 WORKDIR /src
 
 COPY . .
@@ -13,7 +14,15 @@ COPY . .
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
-    && cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} \
+    && case "${TAG}" in \
+        signer-*) \
+            BUILD_ARG="--bin stacks-signer" \
+            ;; \
+        *) \
+            BUILD_ARG="" \
+            ;; \
+    esac \
+    && cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} ${BUILD_ARG} \
     && mkdir -p /out \
     && find ${BUILD_DIR}/target/${TARGET}/release/ -maxdepth 1 -executable -type f | xargs cp -at /out/
 

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-musl-armv7
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-musl-armv7
@@ -5,7 +5,7 @@ ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 ARG BUILD_DIR=/build
 ARG TARGET=armv7-unknown-linux-musleabihf
-ARG TAG="No Tag Info"
+ARG TAG
 WORKDIR /src
 
 COPY . .

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-musl-armv7
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-musl-armv7
@@ -5,6 +5,7 @@ ARG GIT_BRANCH='No Branch Info'
 ARG GIT_COMMIT='No Commit Info'
 ARG BUILD_DIR=/build
 ARG TARGET=armv7-unknown-linux-musleabihf
+ARG TAG="No Tag Info"
 WORKDIR /src
 
 COPY . .
@@ -13,7 +14,15 @@ COPY . .
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
-    && cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} \
+    && case "${TAG}" in \
+        signer-*) \
+            BUILD_ARG="--bin stacks-signer" \
+            ;; \
+        *) \
+            BUILD_ARG="" \
+            ;; \
+    esac \
+    && cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} ${BUILD_ARG} \
     && mkdir -p /out \
     && find ${BUILD_DIR}/target/${TARGET}/release/ -maxdepth 1 -executable -type f | xargs cp -at /out/
 

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-musl-x64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-musl-x64
@@ -7,6 +7,7 @@ ARG BUILD_DIR=/build
 ARG TARGET=x86_64-unknown-linux-musl
 ARG TARGET_CPU
 ENV RUSTFLAGS="${TARGET_CPU:+${RUSTFLAGS} -Ctarget-cpu=${TARGET_CPU}}"
+ARG TAG="No Tag Info"
 WORKDIR /src
 
 COPY . .
@@ -17,7 +18,15 @@ RUN apk update && apk add git musl-dev make
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
-    && cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} \
+    && case "${TAG}" in \
+        signer-*) \
+            BUILD_ARG="--bin stacks-signer" \
+            ;; \
+        *) \
+            BUILD_ARG="" \
+            ;; \
+    esac \
+    && cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} ${BUILD_ARG} \
     && mkdir -p /out \
     && find ${BUILD_DIR}/target/${TARGET}/release/ -maxdepth 1 -executable -type f | xargs cp -at /out/
 

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-musl-x64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.linux-musl-x64
@@ -7,7 +7,7 @@ ARG BUILD_DIR=/build
 ARG TARGET=x86_64-unknown-linux-musl
 ARG TARGET_CPU
 ENV RUSTFLAGS="${TARGET_CPU:+${RUSTFLAGS} -Ctarget-cpu=${TARGET_CPU}}"
-ARG TAG="No Tag Info"
+ARG TAG
 WORKDIR /src
 
 COPY . .

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.macos-arm64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.macos-arm64
@@ -6,7 +6,7 @@ ARG GIT_COMMIT='No Commit Info'
 ARG BUILD_DIR=/build
 ARG OSXCROSS="https://github.com/hirosystems/docker-osxcross-rust/releases/download/MacOSX12.0.sdk/osxcross-d904031_MacOSX12.0.sdk.tar.zst"
 ARG TARGET=aarch64-apple-darwin
-ARG TAG="No Tag Info"
+ARG TAG
 WORKDIR /src
 
 COPY . .

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.macos-arm64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.macos-arm64
@@ -6,6 +6,7 @@ ARG GIT_COMMIT='No Commit Info'
 ARG BUILD_DIR=/build
 ARG OSXCROSS="https://github.com/hirosystems/docker-osxcross-rust/releases/download/MacOSX12.0.sdk/osxcross-d904031_MacOSX12.0.sdk.tar.zst"
 ARG TARGET=aarch64-apple-darwin
+ARG TAG="No Tag Info"
 WORKDIR /src
 
 COPY . .
@@ -21,7 +22,15 @@ RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
     && . /opt/osxcross/env-macos-aarch64 \
-    && cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} \
+    && case "${TAG}" in \
+        signer-*) \
+            BUILD_ARG="--bin stacks-signer" \
+            ;; \
+        *) \
+            BUILD_ARG="" \
+            ;; \
+    esac \
+    && cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} ${BUILD_ARG} \
     && mkdir -p /out \
     && find ${BUILD_DIR}/target/${TARGET}/release/ -maxdepth 1 -executable -type f | xargs cp -at /out/ 
 

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.macos-x64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.macos-x64
@@ -8,6 +8,7 @@ ARG OSXCROSS="https://github.com/hirosystems/docker-osxcross-rust/releases/downl
 ARG TARGET=x86_64-apple-darwin
 ARG TARGET_CPU
 ENV RUSTFLAGS="${TARGET_CPU:+${RUSTFLAGS} -Ctarget-cpu=${TARGET_CPU}}"
+ARG TAG="No Tag Info"
 WORKDIR /src
 
 COPY . .
@@ -23,7 +24,15 @@ RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
     && . /opt/osxcross/env-macos-x86_64 \
-    && cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} \
+    && case "${TAG}" in \
+        signer-*) \
+            BUILD_ARG="--bin stacks-signer" \
+            ;; \
+        *) \
+            BUILD_ARG="" \
+            ;; \
+    esac \
+    && cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} ${BUILD_ARG} \
     && mkdir -p /out \
     && find ${BUILD_DIR}/target/${TARGET}/release/ -maxdepth 1 -executable -type f | xargs cp -at /out/
 

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.macos-x64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.macos-x64
@@ -8,7 +8,7 @@ ARG OSXCROSS="https://github.com/hirosystems/docker-osxcross-rust/releases/downl
 ARG TARGET=x86_64-apple-darwin
 ARG TARGET_CPU
 ENV RUSTFLAGS="${TARGET_CPU:+${RUSTFLAGS} -Ctarget-cpu=${TARGET_CPU}}"
-ARG TAG="No Tag Info"
+ARG TAG
 WORKDIR /src
 
 COPY . .

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.windows-x64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.windows-x64
@@ -7,6 +7,7 @@ ARG BUILD_DIR=/build
 ARG TARGET=x86_64-pc-windows-gnu
 ARG TARGET_CPU
 ENV RUSTFLAGS="${TARGET_CPU:+${RUSTFLAGS} -Ctarget-cpu=${TARGET_CPU}}"
+ARG TAG="No Tag Info"
 WORKDIR /src
 
 COPY . .
@@ -17,9 +18,17 @@ RUN apt-get update && apt-get install -y git gcc-mingw-w64-x86-64 libclang-dev
 RUN --mount=type=tmpfs,target=${BUILD_DIR} cp -R /src/. ${BUILD_DIR}/ \
     && cd ${BUILD_DIR} \
     && rustup target add ${TARGET} \
+    && case "${TAG}" in \
+        signer-*) \
+            BUILD_ARG="--bin stacks-signer" \
+            ;; \
+        *) \
+            BUILD_ARG="" \
+            ;; \
+    esac \
     && CC_x86_64_pc_windows_gnu=x86_64-w64-mingw32-gcc \
     CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=x86_64-w64-mingw32-gcc \
-    cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} \
+    cargo build --features monitoring_prom,slog_json --release --workspace --target ${TARGET} ${BUILD_ARG} \
     && mkdir -p /out \
     && find ${BUILD_DIR}/target/${TARGET}/release/ -maxdepth 1 -executable -type f | xargs cp -at /out/
 

--- a/stacks-core/create-source-binary/build-scripts/Dockerfile.windows-x64
+++ b/stacks-core/create-source-binary/build-scripts/Dockerfile.windows-x64
@@ -7,7 +7,7 @@ ARG BUILD_DIR=/build
 ARG TARGET=x86_64-pc-windows-gnu
 ARG TARGET_CPU
 ENV RUSTFLAGS="${TARGET_CPU:+${RUSTFLAGS} -Ctarget-cpu=${TARGET_CPU}}"
-ARG TAG="No Tag Info"
+ARG TAG
 WORKDIR /src
 
 COPY . .


### PR DESCRIPTION
Make the required modifications in order to be able to release `stacks-node` and `stacks-signer` separately.

**Changes:**
- Add action to check the type of release.
- Output whether the branch name parsed is a release or not.
- Change the Dockerfiles to build only the `stacks-signer` binary if it is a signer release.

**Links:**
- Node Release: https://github.com/BowTiedDevOps/stacks-core/actions/runs/9912429239
- Signer Release: https://github.com/BowTiedDevOps/stacks-core/actions/runs/9912430933
- No Release (CI Workflow ran against `master` branch of `stacks-core`): https://github.com/BowTiedDevOps/stacks-core/actions/runs/9910596033
- No Release (CI Workflow ran against `develop` branch of `stacks-core`): https://github.com/BowTiedDevOps/stacks-core/actions/runs/9910597101