### PR TITLE
Give attribution membership action & format output

### DIFF
--- a/stacks-core/mutation-testing/check-packages-and-shards/README.md
+++ b/stacks-core/mutation-testing/check-packages-and-shards/README.md
@@ -1,6 +1,7 @@
 # Check Packages and Shards action
 
 Checks whether to run mutants on [stackslib](https://github.com/stacks-network/stacks-core/tree/develop/stackslib), [stacks-node](https://github.com/stacks-network/stacks-core/tree/develop/testnet/stacks-node), [stacks-signer](https://github.com/stacks-network/stacks-core/tree/develop/stacks-signer), or small packages (all others), and whether to run them using strategy matrix or not.
+If manually run on CI, it requires a member of [@stacks-network/blockchain-team](https://github.com/orgs/stacks-network/teams/blockchain-team) to trigger the whole mutants workflow.
 
 ## Documentation
 

--- a/stacks-core/mutation-testing/check-packages-and-shards/action.yml
+++ b/stacks-core/mutation-testing/check-packages-and-shards/action.yml
@@ -256,8 +256,8 @@ runs:
           fi
 
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "To ensure these packages are processed, it's recommended to tag @admin in the pull request (PR) so the CI can be extended for this/these package(s)." >> "$GITHUB_STEP_SUMMARY"
-          echo "Alternatively, you can run the packages locally by following the instructions in the documentation (link to docs), but it will take more time." >> "$GITHUB_STEP_SUMMARY"
+          echo "To ensure these packages are processed, it's recommended to tag [@stacks-network/blockchain-team](https://github.com/orgs/stacks-network/teams/blockchain-team) team in the pull request so the CI can be extended for these packages." >> "$GITHUB_STEP_SUMMARY"
+          echo "Alternatively, you can run the packages locally by following the instructions in the [documentation](https://github.com/stacks-network/stacks-core/blob/develop/docs/mutation-testing.md), but it will take more time and the CI action has a better formatted output." >> "$GITHUB_STEP_SUMMARY"
         else
           echo "too_many_mutants=false" >> "$GITHUB_OUTPUT"
         fi

--- a/team-membership/README.md
+++ b/team-membership/README.md
@@ -1,8 +1,11 @@
 # TeamMembership action
 
-Check if the specified user belongs to a given team.
+Modified version of this [composite action](https://github.com/marcocarvalho/team-membership).
 
-It emits one outputs which are available via the `steps` [output context](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#steps-context)
+The primary difference in this action is that it focuses on checking if a specified user is a member of a given team. 
+Additionally, this version runs on Node.js 20 instead of Node.js 16.
+
+The action produces a single output, which can be accessed through the `steps` [output context](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#steps-context).
 
 ## Documentation
 


### PR DESCRIPTION
- give attribution to the initial membership action 
- format the output in summary for too many mutants.
