### PR TITLE
Add `--no-capture` flag to `run-tests`

### DIFF
--- a/stacks-core/run-tests/action.yml
+++ b/stacks-core/run-tests/action.yml
@@ -45,4 +45,5 @@ runs:
           --fail-fast \
           --success-output ${{ inputs.success-output }} \
           --status-level ${{ inputs.status-level }} \
+          --no-capture \
           -E "test(=${{ inputs.test-name }})"


### PR DESCRIPTION
This adds the `--no-capture` flag to `run-tests` which should dump the test logs before the test completes (so even if its killed by GH actions, logs will appear).

See the [nextest docs](https://nexte.st/docs/running/#other-runner-options:~:text=%2D%2Dno%2Dcapture%20%20%20%20%20%20%20%20%20Run%20tests%20serially%20and%20do%20not%20capture%20output) on this command.