### PR TITLE
Feat: use --no-capture when possible

### DIFF
--- a/stacks-core/run-tests/action.yml
+++ b/stacks-core/run-tests/action.yml
@@ -43,6 +43,6 @@ runs:
           --retries ${{ inputs.retries }} \
           --run-ignored all \
           --fail-fast \
-          ${{ inputs.threads == '1' && '' || format('--success-output {0}', inputs.success-output) }} \
+          ${{ inputs.threads != '1' && format('--success-output {0}', inputs.success-output) || '' }} \
           --status-level ${{ inputs.status-level }} \
           -E "test(=${{ inputs.test-name }})"

--- a/stacks-core/run-tests/action.yml
+++ b/stacks-core/run-tests/action.yml
@@ -39,7 +39,7 @@ runs:
         cargo nextest run \
           --verbose \
           --archive-file ${{ inputs.archive-file }} \
-          --test-threads ${{ inputs.threads }} \
+          ${{ inputs.threads == '1' && '--no-capture' || format('--test-threads {0}', inputs.threads) }} \
           --retries ${{ inputs.retries }} \
           --run-ignored all \
           --fail-fast \

--- a/stacks-core/run-tests/action.yml
+++ b/stacks-core/run-tests/action.yml
@@ -43,6 +43,6 @@ runs:
           --retries ${{ inputs.retries }} \
           --run-ignored all \
           --fail-fast \
-          --success-output ${{ inputs.success-output }} \
+          ${{ inputs.threads == '1' && '' || format('--success-output {0}', inputs.success-output) }} \
           --status-level ${{ inputs.status-level }} \
           -E "test(=${{ inputs.test-name }})"


### PR DESCRIPTION
This uses the `--no-capture` flag instead of `--test-threads` when `--test-threads` is set to `1`.

Per the nextest docs, `--no-capture` runs the tests serially (i.e., one test thread) anyways.