### PR TITLE
Adding feature flags for prometheus and slog_json to the archived bin…

### DIFF
--- a/stacks-core/cache/build-cache/action.yml
+++ b/stacks-core/cache/build-cache/action.yml
@@ -73,6 +73,7 @@ runs:
           --workspace \
           --tests \
           --locked \
+          --features monitoring_prom,slog_json \
           --archive-file ~/test_archive.tar.zst
 
     - name: Build and Archive Genesis Tests
@@ -90,7 +91,7 @@ runs:
           --workspace \
           --tests \
           --locked \
-          --features prod-genesis-chainstate \
+          --features prod-genesis-chainstate,monitoring_prom,slog_json \
           --archive-file ~/genesis_archive.tar.zst
 
     ## Save Caches


### PR DESCRIPTION
This should allow creating tests that check monitoring via prometheus

ref: https://github.com/stacks-network/stacks-core/pull/5275