### PR TITLE
fix: set `fail-on-cache-miss` default to `false`

### DIFF
--- a/stacks-core/cache/target/action.yml
+++ b/stacks-core/cache/target/action.yml
@@ -12,7 +12,7 @@ inputs:
   fail-on-cache-miss:
     description: "Fail workflow if cache is not restorable"
     required: false
-    default: "true"
+    default: "false"
   retries:
     description: "Number of attempts"
     required: false
@@ -46,7 +46,7 @@ runs:
         key: ${{ inputs.cache-key }}
 
     ## Restore cache data
-    ## Use wretry action, to retry on a failed upload
+    ## Use wretry action, to retry on a failed download
     - name: Restore Cache
       if: |
         inputs.action == 'restore'


### PR DESCRIPTION
Setting this to true makes a job fail if it does not have a cache hit, but this can happen in valid scenarios, such as retrying a failing test after the cache has been cleared. This causes some flakiness in CI (specifically during retries).

E.g. https://github.com/stacks-network/stacks-core/actions/runs/12794516952/job/35724642399?pr=5706