### PR TITLE
chore: update actions/cache to 4.2.0

### DIFF
--- a/stacks-core/cache/bitcoin/action.yml
+++ b/stacks-core/cache/bitcoin/action.yml
@@ -43,7 +43,7 @@ runs:
       if: |
         inputs.action == 'check' ||
         inputs.action == 'save'
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: check_cache
       with:
         lookup-only: true
@@ -58,7 +58,7 @@ runs:
       id: restore_cache
       uses: Wandalen/wretry.action@6feedb7dedadeb826de0f45ff482b53b379a7844 # v3.5.0
       with:
-        action: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        action: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with: |
           fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
           path: ~/bitcoin
@@ -86,7 +86,7 @@ runs:
       id: save_cache
       uses: Wandalen/wretry.action@6feedb7dedadeb826de0f45ff482b53b379a7844 # v3.5.0
       with:
-        action: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        action: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with: |
           path: ~/bitcoin
           key: ${{ inputs.cache-key }}-${{ inputs.btc-version }}

--- a/stacks-core/cache/cargo/action.yml
+++ b/stacks-core/cache/cargo/action.yml
@@ -39,7 +39,7 @@ runs:
       if: |
         inputs.action == 'check' ||
         inputs.action == 'save'
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: check_cache
       with:
         lookup-only: true
@@ -58,7 +58,7 @@ runs:
       id: restore_cache
       uses: Wandalen/wretry.action@6feedb7dedadeb826de0f45ff482b53b379a7844 # v3.5.0
       with:
-        action: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        action: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with: |
           fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
           path: |
@@ -100,7 +100,7 @@ runs:
       id: save_cache
       uses: Wandalen/wretry.action@6feedb7dedadeb826de0f45ff482b53b379a7844 # v3.5.0
       with:
-        action: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        action: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with: |
           path: |
             ~/.cargo/bin/

--- a/stacks-core/cache/genesis-test-archive/action.yml
+++ b/stacks-core/cache/genesis-test-archive/action.yml
@@ -39,7 +39,7 @@ runs:
       if: |
         inputs.action == 'check' ||
         inputs.action == 'save'
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: check_cache
       with:
         lookup-only: true
@@ -54,7 +54,7 @@ runs:
       id: restore_cache
       uses: Wandalen/wretry.action@6feedb7dedadeb826de0f45ff482b53b379a7844 # v3.5.0
       with:
-        action: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        action: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with: |
           fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
           path: ~/genesis_archive.tar.zst
@@ -71,7 +71,7 @@ runs:
       id: save_cache
       uses: Wandalen/wretry.action@6feedb7dedadeb826de0f45ff482b53b379a7844 # v3.5.0
       with:
-        action: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        action: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with: |
           path: ~/genesis_archive.tar.zst
           key: ${{ inputs.cache-key }}

--- a/stacks-core/cache/target/action.yml
+++ b/stacks-core/cache/target/action.yml
@@ -38,7 +38,7 @@ runs:
     - name: Check Cache
       if: |
         inputs.action == 'check'
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: check_cache
       with:
         lookup-only: true
@@ -53,7 +53,7 @@ runs:
       id: restore_cache
       uses: Wandalen/wretry.action@6feedb7dedadeb826de0f45ff482b53b379a7844 # v3.5.0
       with:
-        action: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        action: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with: |
           fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
           path: ./target
@@ -69,7 +69,7 @@ runs:
       id: save_cache
       uses: Wandalen/wretry.action@6feedb7dedadeb826de0f45ff482b53b379a7844 # v3.5.0
       with:
-        action: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        action: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with: |
           path: ./target
           key: ${{ inputs.cache-key }}

--- a/stacks-core/cache/test-archive/action.yml
+++ b/stacks-core/cache/test-archive/action.yml
@@ -39,7 +39,7 @@ runs:
       if: |
         inputs.action == 'check' ||
         inputs.action == 'save'
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: check_cache
       with:
         lookup-only: true
@@ -54,7 +54,7 @@ runs:
       id: restore_cache
       uses: Wandalen/wretry.action@6feedb7dedadeb826de0f45ff482b53b379a7844 # v3.5.0
       with:
-        action: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        action: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with: |
           fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
           path: ~/test_archive.tar.zst
@@ -71,7 +71,7 @@ runs:
       id: save_cache
       uses: Wandalen/wretry.action@6feedb7dedadeb826de0f45ff482b53b379a7844 # v3.5.0
       with:
-        action: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        action: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with: |
           path: ~/test_archive.tar.zst
           key: ${{ inputs.cache-key }}


### PR DESCRIPTION
Current version of actions/cache is deprecated. All CI jobs depending on it will fail starting March 1. Until then, there are periodic "reminder down times".

See logs: https://productionresultssa2.blob.core.windows.net/actions-results/3f4f4d15-e972-45f0-a3a0-c881ecc6d250/workflow-job-run-361266b1-046a-597d-1939-499416845450/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-02-04T18%3A51%3A04Z&sig=LXkoYr4eAA68WJZxwQiebxehnQ2c7H9X3Rsu0kC4AzE%3D&ske=2025-02-05T03%3A03%3A02Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-02-04T15%3A03%3A02Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-01-05&sp=r&spr=https&sr=b&st=2025-02-04T18%3A40%3A59Z&sv=2025-01-05

And this issue (https://github.com/stacks-network/stacks-core/issues/5799)