### PR TITLE
Add composite workflow for creating PR's on release

### DIFF
--- a/docker/action.yml
+++ b/docker/action.yml
@@ -26,6 +26,8 @@ runs:
     - name: Checkout the latest code
       id: git_checkout
       uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      with:
+        persist-credentials: false
 
     ## Set some vars to be used in the build process
     - name: Set Vars

--- a/stacks-core/release/downstream-pr/README.md
+++ b/stacks-core/release/downstream-pr/README.md
@@ -1,0 +1,28 @@
+# Create downstream PR
+
+When a release branch is built, automatically open a PR against:
+
+- `master`: a PR is opened against `master` using the release branch as the source.
+- `develop`: a PR is opened against `develop`, using the release branch as the source.
+
+If a PR already exists, or there are no changes between branches the action will exit successfully with no PR created.
+
+## Documentation
+
+## Usage
+
+```yaml
+permissions:
+  pull-requests: write
+
+jobs:
+  create-pr:
+    name: Create Downstream PR (${{ github.ref_name }})
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open Downstream PR
+        id: create-pr
+        uses: wileyj/actions/stacks-core/downstream-pr@main
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+```

--- a/stacks-core/release/downstream-pr/README.md
+++ b/stacks-core/release/downstream-pr/README.md
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Open Downstream PR
         id: create-pr
-        uses: wileyj/actions/stacks-core/downstream-pr@main
+        uses: stacks-network/actions/stacks-core/downstream-pr@main
         with:
           token: ${{ secrets.GH_TOKEN }}
 ```

--- a/stacks-core/release/downstream-pr/README.md
+++ b/stacks-core/release/downstream-pr/README.md
@@ -9,6 +9,13 @@ If a PR already exists, or there are no changes between branches the action will
 
 ## Documentation
 
+### Inputs
+
+| Input        | Description        | Required | Default |
+| ------------ | ------------------ | -------- | ------- |
+| `token`      | GitHub Token       | `true`   | null    |
+
+
 ## Usage
 
 ```yaml

--- a/stacks-core/release/downstream-pr/action.yml
+++ b/stacks-core/release/downstream-pr/action.yml
@@ -15,7 +15,7 @@ runs:
   steps:
     - name: Checkout the latest code
       id: git_checkout
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       with:
         fetch-depth: 0
         ref: ${{ github.ref_name }}

--- a/stacks-core/release/downstream-pr/action.yml
+++ b/stacks-core/release/downstream-pr/action.yml
@@ -49,7 +49,6 @@ runs:
         ## set TARGET_BRANCH depending on SOURCE_BRANCH
         for TARGET_BRANCH in {develop,master}; do
           PR_TITLE="Merge ${SOURCE_BRANCH} to ${TARGET_BRANCH}"
-
           ## Check if a PR is open and exists already
           ##   - only look at open PR's
           ##   - jq to check .title for PR_TITLE (with -e option to record exit code)
@@ -58,7 +57,7 @@ runs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls?state=open" \
             | jq -e ".[] | select(.title | contains(\"${PR_TITLE}\"))" > /dev/null 2>&1; echo $?
-          )        
+          )     
           ## if a PR exists, retrieve the PR url
           if [ "${EXISTING_PR}" -eq "0" ];then
             PR=$(gh api \
@@ -71,6 +70,7 @@ runs:
             PR_NUM=$(basename ${PR}) # parse the PR number from the url
             MSG="PR [$PR_NUM]($PR) already exists and is open" # output message to display
             message_out "${MSG}" # store message as annotation
+            break ## break out of the loop, since trying to open a PR when it already exists will cause an error
           fi
 
           ## Check if the target branch exists

--- a/stacks-core/release/downstream-pr/action.yml
+++ b/stacks-core/release/downstream-pr/action.yml
@@ -1,0 +1,111 @@
+name: "Create Downstream PR"
+description: "Create Downstream PR"
+branding:
+  icon: "git-pull-request"
+  color: "gray-dark"
+
+inputs:
+  token:
+    description: "GH_TOKEN"
+    required: true
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout the latest code
+      id: git_checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        fetch-depth: 0
+        ref: ${{ github.ref_name }}
+
+    - name: Create PR
+      id: create-pr
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+
+        ## set some defaults
+        SOURCE_BRANCH=${{ github.ref_name }} # use the source branch that called this workflow
+        TARGET_BRANCH=""
+        COMMIT_HASH=$(git log -1 '--pretty=%H') # retrieve the branch commit hash (used to determine who to assign the PR to)
+        EXIT_CODE=0  # default exit code
+        MSG=""
+        DIFF_OUT="/tmp/diff" # output file to store git diff data
+
+        ## simple function to exit and display some output
+        exit_script() {
+          MSG=${1}
+          EXIT_CODE=${2}
+          cat <<EOF >> $GITHUB_STEP_SUMMARY
+        $MSG
+        EOF
+        exit ${EXIT_CODE}
+        }
+
+        ## set TARGET_BRANCH depending on SOURCE_BRANCH
+        for TARGET_BRANCH in {develop,master}; do
+          PR_TITLE="Merge ${SOURCE_BRANCH} to ${TARGET_BRANCH}"
+
+          ## Check if a PR is open and exists already
+          ##   - only look at open PR's
+          ##   - jq to check .title for PR_TITLE (with -e option to record exit code)
+          EXISTING_PR=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls?state=open" \
+            | jq -e ".[] | select(.title | contains(\"${PR_TITLE}\"))" > /dev/null 2>&1; echo $?
+          )        
+          ## if a PR exists, retrieve the PR url
+          if [ "${EXISTING_PR}" -eq "0" ];then
+            PR=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "/repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/pulls?state=open" \
+              | jq -e ".[] | select(.title | contains(\"${PR_TITLE}\"))" \
+              | jq -r .html_url
+            )
+            PR_NUM=$(basename ${PR}) # parse the PR number from the url
+            MSG="PR [$PR_NUM]($PR) already exists and is open" # output message to display
+            EXIT_CODE=0  # exit code
+            exit_script "${MSG}" "${EXIT_CODE}" # exit with message and exit code
+          fi
+
+          ## Check if the target branch exists
+          if ! git ls-remote --exit-code --quiet --heads origin ${TARGET_BRANCH}; then
+            MSG="Target Branch \`${TARGET_BRANCH}\` does not exist." # output message to display
+            EXIT_CODE=1 # exit code
+            exit_script "${MSG}" "${EXIT_CODE}" # exit with message and exit code
+          fi
+
+          ## fetch the target branch and create a diff
+          git fetch origin ${TARGET_BRANCH}
+          git diff --name-only origin/${TARGET_BRANCH}..origin/${SOURCE_BRANCH} > ${DIFF_OUT}
+          ## check how many lines are in the diff (how many lines have changed)
+          DIFF_NUM=$(sed -n '$=' ${DIFF_OUT})
+
+          ## Finally, create the PR if at least 1 line has changed
+          if [ "${DIFF_NUM}" -gt 0 ]; then
+            PR=$(
+              gh pr create \
+                --head "${SOURCE_BRANCH}" \
+                --base "${TARGET_BRANCH}" \
+                --title "${PR_TITLE}" \
+                --body "Automatic PR to Merge ${SOURCE_BRANCH} to ${TARGET_BRANCH}"
+            )
+            PR_NUM=$(basename "$PR") # parse the PR number from the url
+            MSG="PR [$PR_NUM]($PR) created" # output message to display
+            EXIT_CODE=0 # exit code
+            exit_script "${MSG}" "${EXIT_CODE}" # exit with message and exit code
+          else
+            ## if the diff does not contain at least 1 change, exit successfully with a message
+            MSG="No changes detected between \`${SOURCE_BRANCH}\`->\`${TARGET_BRANCH}\`" # output message to display
+            EXIT_CODE=0 # exit code
+            exit_script "${MSG}" "${EXIT_CODE}" # exit with message and exit code
+          fi
+
+          ## if no other conditions are met, exit with an error
+          exit 1
+        done

--- a/stacks-core/release/downstream-pr/action.yml
+++ b/stacks-core/release/downstream-pr/action.yml
@@ -40,7 +40,6 @@ runs:
           cat <<EOF >> $GITHUB_STEP_SUMMARY
         $MSG
         EOF
-        # exit ${EXIT_CODE}
         }
 
         ## Set default exit code to 0, increment if we have an error for final status (since we're creating PR's in a loop)

--- a/stacks-core/release/downstream-pr/action.yml
+++ b/stacks-core/release/downstream-pr/action.yml
@@ -96,7 +96,7 @@ runs:
                 --body "Automatic PR to Merge ${SOURCE_BRANCH} to ${TARGET_BRANCH}"
             )
             PR_NUM=$(basename "$PR") # parse the PR number from the url
-            MSG="PR [$PR_NUM]($PR) created" # output message to display
+            MSG="\`${SOURCE_BRANCH}\`->\`${TARGET_BRANCH}\` PR [$PR_NUM]($PR) created" # output message to display
             message_out "${MSG}" # store message as annotation
           else
             ## if the diff does not contain at least 1 change, exit successfully with a message

--- a/stacks-core/release/downstream-pr/action.yml
+++ b/stacks-core/release/downstream-pr/action.yml
@@ -26,7 +26,6 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.token }}
       run: |
-
         ## set some defaults
         SOURCE_BRANCH=${{ github.ref_name }} # use the source branch that called this workflow
         TARGET_BRANCH=""

--- a/stacks-core/release/downstream-pr/action.yml
+++ b/stacks-core/release/downstream-pr/action.yml
@@ -36,15 +36,16 @@ runs:
         DIFF_OUT="/tmp/diff" # output file to store git diff data
 
         ## simple function to exit and display some output
-        exit_script() {
+        message_out() {
           MSG=${1}
-          EXIT_CODE=${2}
           cat <<EOF >> $GITHUB_STEP_SUMMARY
         $MSG
         EOF
-        exit ${EXIT_CODE}
+        # exit ${EXIT_CODE}
         }
 
+        ## Set default exit code to 0, increment if we have an error for final status (since we're creating PR's in a loop)
+        EXIT_CODE=0
         ## set TARGET_BRANCH depending on SOURCE_BRANCH
         for TARGET_BRANCH in {develop,master}; do
           PR_TITLE="Merge ${SOURCE_BRANCH} to ${TARGET_BRANCH}"
@@ -69,15 +70,14 @@ runs:
             )
             PR_NUM=$(basename ${PR}) # parse the PR number from the url
             MSG="PR [$PR_NUM]($PR) already exists and is open" # output message to display
-            EXIT_CODE=0  # exit code
-            exit_script "${MSG}" "${EXIT_CODE}" # exit with message and exit code
+            message_out "${MSG}" # store message as annotation
           fi
 
           ## Check if the target branch exists
           if ! git ls-remote --exit-code --quiet --heads origin ${TARGET_BRANCH}; then
             MSG="Target Branch \`${TARGET_BRANCH}\` does not exist." # output message to display
-            EXIT_CODE=1 # exit code
-            exit_script "${MSG}" "${EXIT_CODE}" # exit with message and exit code
+            EXIT_CODE=$((EXIT_CODE+1)) # exit code (error)
+            message_out "${MSG}" # store message as annotation
           fi
 
           ## fetch the target branch and create a diff
@@ -97,15 +97,12 @@ runs:
             )
             PR_NUM=$(basename "$PR") # parse the PR number from the url
             MSG="PR [$PR_NUM]($PR) created" # output message to display
-            EXIT_CODE=0 # exit code
-            exit_script "${MSG}" "${EXIT_CODE}" # exit with message and exit code
+            message_out "${MSG}" # store message as annotation
           else
             ## if the diff does not contain at least 1 change, exit successfully with a message
             MSG="No changes detected between \`${SOURCE_BRANCH}\`->\`${TARGET_BRANCH}\`" # output message to display
-            EXIT_CODE=0 # exit code
-            exit_script "${MSG}" "${EXIT_CODE}" # exit with message and exit code
-          fi
-
-          ## if no other conditions are met, exit with an error
-          exit 1
+            message_out "${MSG}"  # store message as annotation
+          fi 
         done
+        ## exit the script using return code from loop
+        exit ${EXIT_CODE}

--- a/stacks-core/release/downstream-pr/action.yml
+++ b/stacks-core/release/downstream-pr/action.yml
@@ -68,7 +68,7 @@ runs:
               | jq -r .html_url
             )
             PR_NUM=$(basename ${PR}) # parse the PR number from the url
-            MSG="PR [$PR_NUM]($PR) already exists and is open" # output message to display
+            MSG="PR [$PR_NUM]($PR) (\"${PR_TITLE}\") already exists and is open" # output message to display
             message_out "${MSG}" # store message as annotation
             continue ## break out of the loop, since trying to open a PR when it already exists will cause an error
           fi

--- a/stacks-core/release/downstream-pr/action.yml
+++ b/stacks-core/release/downstream-pr/action.yml
@@ -47,7 +47,7 @@ runs:
         ## Set default exit code to 0, increment if we have an error for final status (since we're creating PR's in a loop)
         EXIT_CODE=0
         ## set TARGET_BRANCH depending on SOURCE_BRANCH
-        for TARGET_BRANCH in {develop,master}; do
+        for TARGET_BRANCH in {develop-wileyj,master}; do
           PR_TITLE="Merge ${SOURCE_BRANCH} to ${TARGET_BRANCH}"
           ## Check if a PR is open and exists already
           ##   - only look at open PR's

--- a/stacks-core/release/downstream-pr/action.yml
+++ b/stacks-core/release/downstream-pr/action.yml
@@ -93,10 +93,10 @@ runs:
                 --head "${SOURCE_BRANCH}" \
                 --base "${TARGET_BRANCH}" \
                 --title "${PR_TITLE}" \
-                --body "Automatic PR to Merge ${SOURCE_BRANCH} to ${TARGET_BRANCH}"
+                --body "Release PR to Merge \`${SOURCE_BRANCH}\`->\`${TARGET_BRANCH}\`"
             )
             PR_NUM=$(basename "$PR") # parse the PR number from the url
-            MSG="\`${SOURCE_BRANCH}\`->\`${TARGET_BRANCH}\` PR [$PR_NUM]($PR) created" # output message to display
+            MSG="PR [$PR_NUM]($PR) (\`${SOURCE_BRANCH}\`->\`${TARGET_BRANCH}\`) created" # output message to display
             message_out "${MSG}" # store message as annotation
           else
             ## if the diff does not contain at least 1 change, exit successfully with a message

--- a/stacks-core/release/downstream-pr/action.yml
+++ b/stacks-core/release/downstream-pr/action.yml
@@ -47,7 +47,7 @@ runs:
         ## Set default exit code to 0, increment if we have an error for final status (since we're creating PR's in a loop)
         EXIT_CODE=0
         ## set TARGET_BRANCH depending on SOURCE_BRANCH
-        for TARGET_BRANCH in {develop-wileyj,master}; do
+        for TARGET_BRANCH in {develop,master}; do
           PR_TITLE="Merge ${SOURCE_BRANCH} to ${TARGET_BRANCH}"
           ## Check if a PR is open and exists already
           ##   - only look at open PR's

--- a/stacks-core/release/downstream-pr/action.yml
+++ b/stacks-core/release/downstream-pr/action.yml
@@ -70,7 +70,7 @@ runs:
             PR_NUM=$(basename ${PR}) # parse the PR number from the url
             MSG="PR [$PR_NUM]($PR) already exists and is open" # output message to display
             message_out "${MSG}" # store message as annotation
-            break ## break out of the loop, since trying to open a PR when it already exists will cause an error
+            continue ## break out of the loop, since trying to open a PR when it already exists will cause an error
           fi
 
           ## Check if the target branch exists

--- a/stacks-core/release/downstream-pr/action.yml
+++ b/stacks-core/release/downstream-pr/action.yml
@@ -68,7 +68,7 @@ runs:
               | jq -r .html_url
             )
             PR_NUM=$(basename ${PR}) # parse the PR number from the url
-            MSG="PR [$PR_NUM]($PR) (\"${PR_TITLE}\") already exists and is open" # output message to display
+            MSG="PR [$PR_NUM]($PR) (\`${SOURCE_BRANCH}\`->\`${TARGET_BRANCH}\`) already exists and is open" # output message to display
             message_out "${MSG}" # store message as annotation
             continue ## break out of the loop, since trying to open a PR when it already exists will cause an error
           fi


### PR DESCRIPTION
This composite will create 2 new prs (intended to be run on a release workflow). 
- `release/branch` -> `master`
- `release/branch` -> `develop`

sample PR: https://github.com/wileyj/stacks-core/pull/176

and a sample workflow: https://github.com/wileyj/stacks-core/actions/runs/13656268745

notably - if the PR's already exist, the workflow will not change or open a new one (provided the naming is consistent). 
if there is no diff between the release branch and the target, again - no PR will be created. 

what's not in this composite (ambivalent if it should be) - a check of the source branch name, ensuring that it matches `release/x.x.x.x.x`. i think it would be better suited to use logic in the worfklows that calls this composite than check for it here. 
