### PR TITLE
set persist-credentials to false for docker action checkout

### DIFF
--- a/docker/action.yml
+++ b/docker/action.yml
@@ -26,6 +26,8 @@ runs:
     - name: Checkout the latest code
       id: git_checkout
       uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      with:
+        persist-credentials: false
 
     ## Set some vars to be used in the build process
     - name: Set Vars


### PR DESCRIPTION
As part of the work to simipify docker builds in stacks-network/stacks-core, and the requirement that .git folder is not dockerignored -this specifically sets the actions/checkout step for the docker composite to not store credentials in the git config. 

In testing, this doesn't appear to be required, but it should be safer nevertheless and doesn't harm existing functionality. 

https://github.com/actions/checkout/blob/main/README.md?plain=1#L70-L72