### PR TITLE
Check Versions File on Release

### DIFF
--- a/stacks-core/release/check-release/action.yml
+++ b/stacks-core/release/check-release/action.yml
@@ -29,11 +29,19 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Checkout the latest code
+      id: git_checkout
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
     - name: Set Release Outputs
       id: check_release
       shell: bash
       run: |
         branch_name=${{ inputs.tag }}
+
+        versions_file="versions.toml"
+        node_key="stacks_node_version"
+        signer_key="stacks_signer_version"
 
         stacks_core_version_regex="([0-9]+\.){4}[0-9]+(-rc[0-9]+)?"  # matches x.x.x.x.x || x.x.x.x.x-rcx
         signer_version_regex="([0-9]+\.){5}[0-9]+(-rc[0-9]+)?"   # matches x.x.x.x.x.x || x.x.x.x.x.x-rcx
@@ -72,5 +80,36 @@ runs:
         echo "signer_docker_tag=$signer_docker_tag" >> "$GITHUB_OUTPUT"
         echo "is_node_release=$is_node_release" >> "$GITHUB_OUTPUT"
         echo "is_signer_release=$is_signer_release" >> "$GITHUB_OUTPUT"
+
+        if [[ ! -f "$versions_file" ]]; then
+          echo "Error: $versions_file not found!" >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+        fi
+
+        node_version=$(grep "^$node_key" "$versions_file" | sed -E 's/.*=\s*"([^"]+)"/\1/')
+        signer_version=$(grep "^$signer_key" "$versions_file" | sed -E 's/.*=\s*"([^"]+)"/\1/')
+
+        if [[ -z "$node_version" ]]; then
+          echo "Error: $node_key not found in $versions_file" >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+        fi
+
+        if [[ -z "$signer_version" ]]; then
+          echo "Error: $signer_key not found in $versions_file" >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+        fi
+
+        if [[ "$is_node_release" == "true" && "$node_version" != "$node_docker_tag" ]]; then
+          echo "Error: node version doesn't match in $versions_file" >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+        fi
+
+        if [[ "$signer_version" != "$signer_docker_tag" ]]; then
+          echo "Error: signer version doesn't match in $versions_file" >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+        fi
+
+        echo "Node version: $node_version"
+        echo "Signer version: $signer_version"
 
         exit 0

--- a/stacks-core/release/downstream-pr/action.yml
+++ b/stacks-core/release/downstream-pr/action.yml
@@ -15,7 +15,7 @@ runs:
   steps:
     - name: Checkout the latest code
       id: git_checkout
-      uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
         ref: ${{ github.ref_name }}


### PR DESCRIPTION
### Description

Updated the `check-release` job to also check if the branch name matches the versions in the `versions.toml` file from the `stacks-core` repository when a release happens.

### Test Runs
- No Release: https://github.com/BowTiedDevOps/stacks-core/actions/runs/13811089162
- Missing Versions File: https://github.com/BowTiedDevOps/stacks-core/actions/runs/13811338564

---

- Failed Node Release (versions not matching): https://github.com/BowTiedDevOps/stacks-core/actions/runs/13811146056
- Failed Node Release (file is missing version): https://github.com/BowTiedDevOps/stacks-core/actions/runs/13811225529
- Failed Node Release (file contains good node version, but bad signer version): https://github.com/BowTiedDevOps/stacks-core/actions/runs/13811288588
- Successful Node Release: https://github.com/BowTiedDevOps/stacks-core/actions/runs/13811315744

---

- Failed Signer Release (versions not matching): https://github.com/BowTiedDevOps/stacks-core/actions/runs/13811172404
- Failed Signer Release (file is missing version): https://github.com/BowTiedDevOps/stacks-core/actions/runs/13811227898
- Successful Signer Release: https://github.com/BowTiedDevOps/stacks-core/actions/runs/13811317572