### PR TITLE
Build docker images for linux/arm64 OS architectures #5920

### DIFF
--- a/stacks-core/release/create-docker-image/README.md
+++ b/stacks-core/release/create-docker-image/README.md
@@ -13,6 +13,7 @@ Creates a docker image for the given tag and uploads it to dockerhub.
 | `DOCKERHUB_USERNAME` | Docker username for publishing images | `true`   | null    |
 | `DOCKERHUB_PASSWORD` | Docker password for publishing images | `true`   | null    |
 | `dist`               | Linux Distribution to build for       | `true`   | null    |
+| `platforms`          | Docker platforms to build for         | `false`  | `linux/arm64, linux/arm/v7, linux/amd64, linux/amd64/v3` |
 
 ## Usage
 

--- a/stacks-core/release/create-docker-image/action.yml
+++ b/stacks-core/release/create-docker-image/action.yml
@@ -114,7 +114,6 @@ runs:
       uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
       with:
         file: ./.github/actions/dockerfiles/Dockerfile.${{ matrix.dist }}-binary
-        # define the platforms we're building for
         platforms: ${{ inputs.platforms }}
         tags: ${{ steps.docker_metadata_signer.outputs.tags }}
         labels: ${{ steps.docker_metadata_signer.outputs.labels }}
@@ -133,7 +132,6 @@ runs:
       uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
       with:
         file: ./.github/actions/dockerfiles/Dockerfile.${{ matrix.dist }}-binary
-        # define the platforms we're building for
         platforms: ${{ inputs.platforms }}
         tags: ${{ steps.docker_metadata_node.outputs.tags }}
         labels: ${{ steps.docker_metadata_node.outputs.labels }}

--- a/stacks-core/release/create-docker-image/action.yml
+++ b/stacks-core/release/create-docker-image/action.yml
@@ -110,7 +110,8 @@ runs:
       uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
       with:
         file: ./.github/actions/dockerfiles/Dockerfile.${{ matrix.dist }}-binary
-        platforms: ${{ env.docker_platforms }}
+	# define the platforms we're building for
+        platforms: "linux/arm64, linux/arm/v7, linux/amd64, linux/amd64/v3"
         tags: ${{ steps.docker_metadata_signer.outputs.tags }}
         labels: ${{ steps.docker_metadata_signer.outputs.labels }}
         build-args: |
@@ -128,7 +129,8 @@ runs:
       uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
       with:
         file: ./.github/actions/dockerfiles/Dockerfile.${{ matrix.dist }}-binary
-        platforms: ${{ env.docker_platforms }}
+	# define the platforms we're building for
+        platforms: "linux/arm64, linux/arm/v7, linux/amd64, linux/amd64/v3"
         tags: ${{ steps.docker_metadata_node.outputs.tags }}
         labels: ${{ steps.docker_metadata_node.outputs.labels }}
         build-args: |

--- a/stacks-core/release/create-docker-image/action.yml
+++ b/stacks-core/release/create-docker-image/action.yml
@@ -114,7 +114,7 @@ runs:
       uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
       with:
         file: ./.github/actions/dockerfiles/Dockerfile.${{ matrix.dist }}-binary
-	# define the platforms we're building for
+        # define the platforms we're building for
         platforms: ${{ inputs.platforms }}
         tags: ${{ steps.docker_metadata_signer.outputs.tags }}
         labels: ${{ steps.docker_metadata_signer.outputs.labels }}
@@ -133,7 +133,7 @@ runs:
       uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
       with:
         file: ./.github/actions/dockerfiles/Dockerfile.${{ matrix.dist }}-binary
-	# define the platforms we're building for
+        # define the platforms we're building for
         platforms: ${{ inputs.platforms }}
         tags: ${{ steps.docker_metadata_node.outputs.tags }}
         labels: ${{ steps.docker_metadata_node.outputs.labels }}

--- a/stacks-core/release/create-docker-image/action.yml
+++ b/stacks-core/release/create-docker-image/action.yml
@@ -21,6 +21,10 @@ inputs:
   dist:
     description: "Linux Distribution to build for"
     required: true
+  platforms:
+    description: "Docker platforms to build for"
+    required: false
+    default: "linux/arm64, linux/arm/v7, linux/amd64, linux/amd64/v3"
 
 runs:
   using: "composite"
@@ -111,7 +115,7 @@ runs:
       with:
         file: ./.github/actions/dockerfiles/Dockerfile.${{ matrix.dist }}-binary
 	# define the platforms we're building for
-        platforms: "linux/arm64, linux/arm/v7, linux/amd64, linux/amd64/v3"
+        platforms: ${{ inputs.platforms }}
         tags: ${{ steps.docker_metadata_signer.outputs.tags }}
         labels: ${{ steps.docker_metadata_signer.outputs.labels }}
         build-args: |
@@ -130,7 +134,7 @@ runs:
       with:
         file: ./.github/actions/dockerfiles/Dockerfile.${{ matrix.dist }}-binary
 	# define the platforms we're building for
-        platforms: "linux/arm64, linux/arm/v7, linux/amd64, linux/amd64/v3"
+        platforms: ${{ inputs.platforms }}
         tags: ${{ steps.docker_metadata_node.outputs.tags }}
         labels: ${{ steps.docker_metadata_node.outputs.labels }}
         build-args: |

--- a/stacks-core/release/docker-images/action.yml
+++ b/stacks-core/release/docker-images/action.yml
@@ -42,8 +42,7 @@ runs:
       if: |
         inputs.is_node_release == 'true'
       id: create_node_release
-      uses: wileyj/actions/stacks-core/release/create-docker-image@fix/docker_platforms
-      #uses: stacks-network/actions/stacks-core/release/create-docker-image@main
+      uses: stacks-network/actions/stacks-core/release/create-docker-image@main
       with:
         tag: ${{ inputs.node_tag }}
         docker_tag: ${{ inputs.node_docker_tag }}
@@ -56,8 +55,7 @@ runs:
       if: |
         inputs.is_signer_release == 'true'
       id: create_signer_release
-      uses: wileyj/actions/stacks-core/release/create-docker-image@fix/docker_platforms
-      #uses: stacks-network/actions/stacks-core/release/create-docker-image@main
+      uses: stacks-network/actions/stacks-core/release/create-docker-image@main
       with:
         tag: ${{ inputs.signer_tag }}
         docker_tag: ${{ inputs.signer_docker_tag }}

--- a/stacks-core/release/docker-images/action.yml
+++ b/stacks-core/release/docker-images/action.yml
@@ -50,7 +50,6 @@ runs:
         DOCKERHUB_USERNAME: ${{ inputs.DOCKERHUB_USERNAME }}
         DOCKERHUB_PASSWORD: ${{ inputs.DOCKERHUB_PASSWORD }}
         dist: ${{ inputs.dist }}
-	
 
     ## Creates the signer docker image
     - name: Create Signer Docker Image

--- a/stacks-core/release/docker-images/action.yml
+++ b/stacks-core/release/docker-images/action.yml
@@ -42,20 +42,23 @@ runs:
       if: |
         inputs.is_node_release == 'true'
       id: create_node_release
-      uses: stacks-network/actions/stacks-core/release/create-docker-image@main
+      uses: wileyj/actions/stacks-core/release/create-docker-image@fix/docker_platforms
+      #uses: stacks-network/actions/stacks-core/release/create-docker-image@main
       with:
         tag: ${{ inputs.node_tag }}
         docker_tag: ${{ inputs.node_docker_tag }}
         DOCKERHUB_USERNAME: ${{ inputs.DOCKERHUB_USERNAME }}
         DOCKERHUB_PASSWORD: ${{ inputs.DOCKERHUB_PASSWORD }}
         dist: ${{ inputs.dist }}
+	
 
     ## Creates the signer docker image
     - name: Create Signer Docker Image
       if: |
         inputs.is_signer_release == 'true'
       id: create_signer_release
-      uses: stacks-network/actions/stacks-core/release/create-docker-image@main
+      uses: wileyj/actions/stacks-core/release/create-docker-image@fix/docker_platforms
+      #uses: stacks-network/actions/stacks-core/release/create-docker-image@main
       with:
         tag: ${{ inputs.signer_tag }}
         docker_tag: ${{ inputs.signer_docker_tag }}


### PR DESCRIPTION
https://github.com/stacks-network/stacks-core/issues/5920

fixes the composite action that builds docker images so all expected platforms are uploaded to a docker repo. 

`create-docker-image` now has an additional input of `platforms`, which defaults to the expected values `linux/arm64, linux/arm/v7, linux/amd64, linux/amd64/v3`, but may be overridden by the calling workflow. 



https://hub.docker.com/r/wileyj/stacks-core/tags?name=3.1.0.0.10-rc1
https://github.com/wileyj/stacks-core/actions/runs/13861429704
