### PR TITLE
Add image and binary attestation

### DIFF
--- a/stacks-core/release/create-docker-image/action.yml
+++ b/stacks-core/release/create-docker-image/action.yml
@@ -107,6 +107,47 @@ runs:
           type=raw,value=latest-${{ matrix.dist }},enable=${{ inputs.docker_tag != '' && env.docker_tag_rc != 'true' && matrix.dist == 'alpine' }}
           type=raw,value=${{ inputs.docker_tag }}-${{ matrix.dist }},enable=${{ inputs.docker_tag != '' && matrix.dist == 'alpine' }}
 
+    ## Build docker image for node release
+    - name: Build and Push ( ${{matrix.dist}} )
+      if: ${{ env.is-signer-release == 'false' }}
+      id: docker_build_node
+      uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
+      with:
+        file: ./.github/actions/dockerfiles/Dockerfile.${{ matrix.dist }}-binary
+        platforms: ${{ inputs.platforms }}
+        tags: ${{ steps.docker_metadata_node.outputs.tags }}
+        labels: ${{ steps.docker_metadata_node.outputs.labels }}
+        build-args: |
+          TAG=${{ inputs.tag }}
+          REPO=${{ github.repository_owner }}/${{ github.event.repository.name }}
+          STACKS_NODE_VERSION=${{ inputs.tag || env.GITHUB_SHA_SHORT }}
+          GIT_BRANCH=${{ env.GITHUB_REF_SHORT }}
+          GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
+        push: ${{ env.DOCKER_PUSH }}
+
+    ## Generate docker image attestation(s)
+    ## attest repo-name:tag
+    - name: Generate artifact attestation (${{ github.event.repository.name }})
+      if: ${{ env.is-signer-release == 'false' }}
+      id: attest_node_primary
+      uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
+      with:
+        subject-name: |
+          index.docker.io/${{env.docker-org}}/${{ github.event.repository.name }}
+        subject-digest: ${{ steps.docker_build_node.outputs.digest }}
+        push-to-registry: true
+
+    ## attest stacks-blockchain:tag
+    - name: Generate artifact attestation (stacks-blockchain)
+      if: ${{ env.is-signer-release == 'false' }}
+      id: attest_node_secondary
+      uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
+      with:
+        subject-name: |
+          index.docker.io/${{env.docker-org}}/stacks-blockchain
+        subject-digest: ${{ steps.docker_build_node.outputs.digest }}
+        push-to-registry: true
+
     ## Build docker image for signer release
     - name: Build and Push ( ${{matrix.dist}} )
       if: ${{ env.is-signer-release == 'true' }}
@@ -125,20 +166,14 @@ runs:
           GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
         push: ${{ env.DOCKER_PUSH }}
 
-    ## Build docker image for node release
-    - name: Build and Push ( ${{matrix.dist}} )
-      if: ${{ env.is-signer-release == 'false' }}
-      id: docker_build_node
-      uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
+    ## Generate docker image attestation(s)
+    ## attest stacks-signer:tag
+    - name: Generate artifact attestation (${{matrix.dist}} stacks-signer )
+      if: ${{ env.is-signer-release == 'true' }}
+      id: attest_signer_primary
+      uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
       with:
-        file: ./.github/actions/dockerfiles/Dockerfile.${{ matrix.dist }}-binary
-        platforms: ${{ inputs.platforms }}
-        tags: ${{ steps.docker_metadata_node.outputs.tags }}
-        labels: ${{ steps.docker_metadata_node.outputs.labels }}
-        build-args: |
-          TAG=${{ inputs.tag }}
-          REPO=${{ github.repository_owner }}/${{ github.event.repository.name }}
-          STACKS_NODE_VERSION=${{ inputs.tag || env.GITHUB_SHA_SHORT }}
-          GIT_BRANCH=${{ env.GITHUB_REF_SHORT }}
-          GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
-        push: ${{ env.DOCKER_PUSH }}
+        subject-name: |
+          index.docker.io/${{env.docker-org}}/stacks-signer
+        subject-digest: ${{ steps.docker_build_signer.outputs.digest }}
+        push-to-registry: true

--- a/stacks-core/release/create-source-binary/action.yml
+++ b/stacks-core/release/create-source-binary/action.yml
@@ -115,6 +115,7 @@ runs:
         signer_docker_tag: ${{ inputs.signer_docker_tag }}
         node_tag: ${{ inputs.node_tag }}
 
+    ## Attest the release binaries
     - name: Attest release artifact
       uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 #v2.2.3
       with:

--- a/stacks-core/release/create-source-binary/action.yml
+++ b/stacks-core/release/create-source-binary/action.yml
@@ -114,3 +114,8 @@ runs:
         cpu: ${{ inputs.cpu }}
         signer_docker_tag: ${{ inputs.signer_docker_tag }}
         node_tag: ${{ inputs.node_tag }}
+
+    - name: Attest release artifact
+      uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 #v2.2.3
+      with:
+        subject-path: ${{ env.ZIPFILE }}.zip

--- a/stacks-core/release/downstream-pr/action.yml
+++ b/stacks-core/release/downstream-pr/action.yml
@@ -33,6 +33,8 @@ runs:
         EXIT_CODE=0  # default exit code
         MSG=""
         DIFF_OUT="/tmp/diff" # output file to store git diff data
+        ## PR target branches  (default to develop & master)
+        PR_TARGETS=(develop master)
 
         ## simple function to exit and display some output
         message_out() {
@@ -42,10 +44,18 @@ runs:
         EOF
         }
 
+        ## check if the branch name matches a release candidate
+        stacks_core_regex="release/([0-9]+\.){4}[0-9]-rc[0-9]*$"
+        signer_regex="release/signer-([0-9]+\.){5}[0-9]-rc[0-9]*$"
+        if [[ "$branch_name" =~ ^${signer_regex}$ || "$branch_name" =~ ^${stacks_core_regex}$ ]]; then
+          ## if the branch matches an rc pattern, only PR back to develop
+          PR_TARGETS=(develop)
+        fi
+
         ## Set default exit code to 0, increment if we have an error for final status (since we're creating PR's in a loop)
         EXIT_CODE=0
         ## set TARGET_BRANCH depending on SOURCE_BRANCH
-        for TARGET_BRANCH in {develop,master}; do
+        for TARGET_BRANCH in ${PR_TARGETS[@]}; do
           PR_TITLE="Merge ${SOURCE_BRANCH} to ${TARGET_BRANCH}"
           ## Check if a PR is open and exists already
           ##   - only look at open PR's

--- a/stacks-core/release/downstream-pr/action.yml
+++ b/stacks-core/release/downstream-pr/action.yml
@@ -47,7 +47,7 @@ runs:
         ## check if the branch name matches a release candidate
         stacks_core_regex="release/([0-9]+\.){4}[0-9]-rc[0-9]*$"
         signer_regex="release/signer-([0-9]+\.){5}[0-9]-rc[0-9]*$"
-        if [[ "$SOURCE_BRANCH" =~ ^${signer_regex}$ || "$branch_name" =~ ^${stacks_core_regex}$ ]]; then
+        if [[ "$SOURCE_BRANCH" =~ ^${signer_regex}$ || "$SOURCE_BRANCH" =~ ^${stacks_core_regex}$ ]]; then
           ## if the branch matches an rc pattern, only PR back to develop
           PR_TARGETS=(develop)
         fi

--- a/stacks-core/release/downstream-pr/action.yml
+++ b/stacks-core/release/downstream-pr/action.yml
@@ -47,7 +47,7 @@ runs:
         ## check if the branch name matches a release candidate
         stacks_core_regex="release/([0-9]+\.){4}[0-9]-rc[0-9]*$"
         signer_regex="release/signer-([0-9]+\.){5}[0-9]-rc[0-9]*$"
-        if [[ "$branch_name" =~ ^${signer_regex}$ || "$branch_name" =~ ^${stacks_core_regex}$ ]]; then
+        if [[ "$SOURCE_BRANCH" =~ ^${signer_regex}$ || "$branch_name" =~ ^${stacks_core_regex}$ ]]; then
           ## if the branch matches an rc pattern, only PR back to develop
           PR_TARGETS=(develop)
         fi


### PR DESCRIPTION
Enables attestation steps for both docker images and the release archive (which the image is built from). 

Secondly, this changes the downstream_pr composite to not create a PR to master (only develop) when the release is an rc. 

