### PR TITLE
Bump default btc version to 25.0 and change the cache key for bitcoin…

### DIFF
--- a/stacks-core/cache/bitcoin/README.md
+++ b/stacks-core/cache/bitcoin/README.md
@@ -9,20 +9,21 @@ Generic cache operations for the bitcoin cache:
 ## Documentation
 
 ### Inputs
-| Input | Description | Required | Default |
-| ------------------------------- | ----------------------------------------------------- | ------------------------- | ------------------------- |
-| `action` | Type of cache action - one of: `check`, `restore`, `save` | true | `check` |
-| `cache-key` | Cache Key name | false | `${{ github.event.repository.name }}-${{ github.sha }}-test-archive` |
-| `fail_ci_if_error` | Fail the workflow on an error | false | `false` |
-| `retries` | Number of times to retry codecov upload | false | `3` |
-| `retry-delay` | Time in ms between upload retries | false | `10000` |
-| `btc-version` | The version of Bitcoin to use | false | `0.20.0` |
+
+| Input              | Description                                               | Required | Default                                                              |
+| ------------------ | --------------------------------------------------------- | -------- | -------------------------------------------------------------------- |
+| `action`           | Type of cache action - one of: `check`, `restore`, `save` | true     | `check`                                                              |
+| `cache-key`        | Cache Key name                                            | false    | `${{ github.event.repository.name }}-${{ github.sha }}-test-archive` |
+| `fail_ci_if_error` | Fail the workflow on an error                             | false    | `false`                                                              |
+| `retries`          | Number of times to retry codecov upload                   | false    | `3`                                                                  |
+| `retry-delay`      | Time in ms between upload retries                         | false    | `10000`                                                              |
+| `btc-version`      | The version of Bitcoin to use                             | false    | `25.0`                                                               |
 
 ### Outputs
-| Output | Description |
-| ------------------------------- | ----------------------------------------------------- | 
-| `cache-hit` | Returns a boolean if a cache is found (_only applicable in the `check` input action_) |
 
+| Output      | Description                                                                           |
+| ----------- | ------------------------------------------------------------------------------------- |
+| `cache-hit` | Returns a boolean if a cache is found (_only applicable in the `check` input action_) |
 
 ## Usage
 

--- a/stacks-core/cache/bitcoin/README.md
+++ b/stacks-core/cache/bitcoin/README.md
@@ -10,14 +10,14 @@ Generic cache operations for the bitcoin cache:
 
 ### Inputs
 
-| Input              | Description                                               | Required | Default                                                              |
-| ------------------ | --------------------------------------------------------- | -------- | -------------------------------------------------------------------- |
-| `action`           | Type of cache action - one of: `check`, `restore`, `save` | true     | `check`                                                              |
-| `cache-key`        | Cache Key name                                            | false    | `${{ github.event.repository.name }}-${{ github.sha }}-test-archive` |
-| `fail_ci_if_error` | Fail the workflow on an error                             | false    | `false`                                                              |
-| `retries`          | Number of times to retry codecov upload                   | false    | `3`                                                                  |
-| `retry-delay`      | Time in ms between upload retries                         | false    | `10000`                                                              |
-| `btc-version`      | The version of Bitcoin to use                             | false    | `25.0`                                                               |
+| Input              | Description                                               | Required | Default                                                                   |
+| ------------------ | --------------------------------------------------------- | -------- | ------------------------------------------------------------------------- |
+| `action`           | Type of cache action - one of: `check`, `restore`, `save` | true     | `check`                                                                   |
+| `cache-key`        | Cache Key name                                            | false    | `$${{ github.event.repository.name }}-${{ github.sha }}-bitcoin-binaries` |
+| `fail_ci_if_error` | Fail the workflow on an error                             | false    | `false`                                                                   |
+| `retries`          | Number of times to retry codecov upload                   | false    | `3`                                                                       |
+| `retry-delay`      | Time in ms between upload retries                         | false    | `10000`                                                                   |
+| `btc-version`      | The version of Bitcoin to use                             | false    | `25.0`                                                                    |
 
 ### Outputs
 

--- a/stacks-core/cache/bitcoin/action.yml
+++ b/stacks-core/cache/bitcoin/action.yml
@@ -24,11 +24,11 @@ inputs:
   cache-key:
     description: "Cache Key name"
     required: false
-    default: ${{ github.event.repository.name }}-bitcoin-binaries
+    default: ${{ github.event.repository.name }}-${{ github.event.pull_request.head.sha || github.sha }}-bitcoin-binaries
   btc-version:
     description: "Bitcoin version"
     required: false
-    default: "0.20.0"
+    default: "25.0"
 
 outputs:
   cache-hit:

--- a/stacks-core/testenv/action.yml
+++ b/stacks-core/testenv/action.yml
@@ -12,7 +12,7 @@ inputs:
   btc-version:
     description: "Bitcoin version"
     required: false
-    default: "0.20.0"
+    default: "25.0"
 
 runs:
   using: "composite"


### PR DESCRIPTION
band-aid for the issue in https://github.com/stacks-network/stacks-core/issues/6107

this should temp. resolve the observed behaviour by changing the bitcoin binary cache key to use a commit sha. this will result in more bitcoin archives in the cache, but they're only 44MB in size so it's not likely to cause any immediate problems while a more thorough solution to 6107 is worked on. 

secondly, default bitcoin version is bumped to 25.0 which is being used as an input in the calling workflows. 

example workflow using the new cache key: https://github.com/wileyj/stacks-core/actions/runs/15118422126/job/42495790916#step:4:1029

no changes are required in stacks-core - once this PR is merged to main, any workflow in stacks-core will start using the new cache key. 