### PR TITLE
Update taiki-e workflow version 

### DIFF
--- a/stacks-core/cache/cargo/action.yml
+++ b/stacks-core/cache/cargo/action.yml
@@ -77,18 +77,17 @@ runs:
         inputs.action == 'save' &&
         steps.check_cache.outputs.cache-hit != 'true'
       id: install_nextest
-      uses: taiki-e/install-action@54b836426b3fa9aef432e760885ea0419ab50dab # v2.48.15
+      uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb # v2.53.2
       with:
         tool: nextest # can be versioned, ex: tool@1.1.1.1
 
     ## If cargo cache is not found, install grcov
-    ##  - cargo-llvm-cov instead? https://github.com/taiki-e/cargo-llvm-cov
     - name: Install grcov
       if: |
         inputs.action == 'save' &&
         steps.check_cache.outputs.cache-hit != 'true'
       id: install_grcov
-      uses: taiki-e/install-action@54b836426b3fa9aef432e760885ea0419ab50dab # v2.48.15
+      uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb # v2.53.2
       with:
         tool: grcov # can be versioned, ex: tool@1.1.1.1
 

--- a/stacks-core/mutation-testing/pr-differences/action.yml
+++ b/stacks-core/mutation-testing/pr-differences/action.yml
@@ -41,7 +41,7 @@ runs:
       run: |
         cargo install --version 24.7.1 cargo-mutants --locked # v24.7.1
 
-    - uses: taiki-e/install-action@54b836426b3fa9aef432e760885ea0419ab50dab # v2.48.15
+    - uses: taiki-e/install-action@d12e869b89167df346dd0ff65da342d1fb1202fb # v2.53.2
       name: Install cargo-nextest
       id: install_cargo_nextest
       with:


### PR DESCRIPTION
Use the latest `taiki-e/install-action` version, which has a fix for the `403` encountered when installing nextest specifically: 
https://github.com/taiki-e/install-action/pull/1007

