### PR TITLE
update `build-cache` to support `stacks-node` as root folder

### DIFF
--- a/stacks-core/cache/build-cache/action.yml
+++ b/stacks-core/cache/build-cache/action.yml
@@ -87,6 +87,7 @@ runs:
       shell: bash
       run: |
         # TEMPORARY FALLBACK: Support both old and new directory layouts until full rollout is complete
+        # issue reference: https://github.com/stacks-network/actions/issues/79
         if [ -d testnet/stacks-node ]; then
           cd testnet/stacks-node
         elif [ -d stacks-node ]; then

--- a/stacks-core/cache/build-cache/action.yml
+++ b/stacks-core/cache/build-cache/action.yml
@@ -86,7 +86,17 @@ runs:
       id: archive_genesis_tests
       shell: bash
       run: |
-        cd testnet/stacks-node && cargo nextest archive \
+        # TEMPORARY FALLBACK: Support both old and new directory layouts until full rollout is complete
+        if [ -d testnet/stacks-node ]; then
+          cd testnet/stacks-node
+        elif [ -d stacks-node ]; then
+          cd stacks-node
+        else
+          echo "Error: Neither testnet/stacks-node nor stacks-node directory exists."
+          exit 1
+        fi
+
+        cargo nextest archive \
           --build-jobs 8 \
           --workspace \
           --tests \

--- a/stacks-core/mutation-testing/check-packages-and-shards/README.md
+++ b/stacks-core/mutation-testing/check-packages-and-shards/README.md
@@ -1,6 +1,6 @@
 # Check Packages and Shards action
 
-Checks whether to run mutants on [stackslib](https://github.com/stacks-network/stacks-core/tree/develop/stackslib), [stacks-node](https://github.com/stacks-network/stacks-core/tree/develop/testnet/stacks-node), [stacks-signer](https://github.com/stacks-network/stacks-core/tree/develop/stacks-signer), or small packages (all others), and whether to run them using strategy matrix or not.
+Checks whether to run mutants on [stackslib](https://github.com/stacks-network/stacks-core/tree/develop/stackslib), [stacks-node](https://github.com/stacks-network/stacks-core/tree/develop/stacks-node), [stacks-signer](https://github.com/stacks-network/stacks-core/tree/develop/stacks-signer), or small packages (all others), and whether to run them using strategy matrix or not.
 If manually run on CI, it requires a member of [@stacks-network/blockchain-team](https://github.com/orgs/stacks-network/teams/blockchain-team) to trigger the whole mutants workflow.
 
 ## Documentation

--- a/stacks-core/mutation-testing/pr-differences/README.md
+++ b/stacks-core/mutation-testing/pr-differences/README.md
@@ -9,7 +9,7 @@ Run mutants for differences in pull requests, and upload the mutant outcomes and
 | Input | Description | Required | Default |
 | ------------------------------- | ----------------------------------------------------- | ------------------------- | ------------------------- |
 | `shard` | The number of the shard to run (`-1` if ran without shards) | false | -1 |
-| `package` | The package to run mutants on. [Stackslib](https://github.com/stacks-network/stacks-core/tree/develop/stackslib), [stacks-node](https://github.com/stacks-network/stacks-core/tree/develop/testnet/stacks-node) and [stacks-signer](https://github.com/stacks-network/stacks-core/tree/develop/stacks-signer) are independent, all others are run as `small`. | true |  |
+| `package` | The package to run mutants on. [Stackslib](https://github.com/stacks-network/stacks-core/tree/develop/stackslib), [stacks-node](https://github.com/stacks-network/stacks-core/tree/develop/stacks-node) and [stacks-signer](https://github.com/stacks-network/stacks-core/tree/develop/stacks-signer) are independent, all others are run as `small`. | true |  |
 
 ## Usage
 


### PR DESCRIPTION
This patch introduces a temporary fallback mechanism to support the relocation of `stacks-node` from `testnet/stacks-node` to the workspace root (`stacks-node/`).

The change ensures that CI continues to function during the transition described in [PR #6254](https://github.com/stacks-network/stacks-core/pull/6254) by checking for both possible paths when generating the Nextest archive:
- `testnet/stacks-node`
- `stacks-node`

If the old path is found, it's used; otherwise, it try for the new path. This allows CI to work seamlessly across mixed environments during the rollout.

Once the migration is fully complete and the old path is no longer used, the fallback logic for `testnet/stacks-node` can be safely removed in a future cleanup PR.
