### PR TITLE
refactor: remove stacks-node fallback in build-cache action

### DIFF
--- a/stacks-core/cache/build-cache/action.yml
+++ b/stacks-core/cache/build-cache/action.yml
@@ -86,18 +86,7 @@ runs:
       id: archive_genesis_tests
       shell: bash
       run: |
-        # TEMPORARY FALLBACK: Support both old and new directory layouts until full rollout is complete
-        # issue reference: https://github.com/stacks-network/actions/issues/79
-        if [ -d testnet/stacks-node ]; then
-          cd testnet/stacks-node
-        elif [ -d stacks-node ]; then
-          cd stacks-node
-        else
-          echo "Error: Neither testnet/stacks-node nor stacks-node directory exists."
-          exit 1
-        fi
-
-        cargo nextest archive \
+        cd stacks-node && cargo nextest archive \
           --build-jobs 8 \
           --workspace \
           --tests \


### PR DESCRIPTION
This patch clean-up the fallback mechanism introduced with #78 (when moved `stacks-node` to the workspace root)

Closes #79