### PR TITLE
Updated many action versions, removed usage of wretry, updated READMEs, and removed --build-jobs flag from build-cache actions because it was set to 8 on runners with 4 CPUs which is bad

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Stacks Network github actions
+# Stacks Network GitHub Actions
 
 Monorepo of [composite actions](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action) used in the [stacks-network](https://github.com/stacks-network) org
 
-- [codecov](./codecov) - Uploads codecov reports with a retry if it fails (optionally it can run grcov to generate a report to send)
+- [codecov](./codecov) - Generates code coverage reports and uploads them to GitHub artifacts to be used later in the CI pipeline
 - [openapi](./openapi) - Generates and uploads an [OpenAPI](https://spec.openapis.org/oas/latest.html) artifact
 - [docker](./docker) - Generic Docker setup workflows
 - [generate-checksum](./generate-checksum/) - Generate a 512-bit `sha` hash of the uploaded artifacts

--- a/codecov/action.yml
+++ b/codecov/action.yml
@@ -67,5 +67,5 @@ runs:
         path: ${{ steps.generate_test_file_name.outputs.result }}
         if-no-files-found: error
         retention-days: 1
-        compression-level: 0 # 0 (none) - 9 (most)
+        compression-level: 9 # 0 (none) - 9 (most)
         overwrite: true

--- a/openapi/action.yml
+++ b/openapi/action.yml
@@ -37,10 +37,10 @@ runs:
   steps:
     - name: Checkout the latest code
       id: git_checkout
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: "${{ inputs.node-version }}"
 

--- a/rustfmt/README.md
+++ b/rustfmt/README.md
@@ -32,10 +32,10 @@ jobs:
     name: cargo fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Ensure rustfmt is installed and setup problem matcher
-      - uses: actions-rust-lang/setup-rust-toolchain@b113a30d27a8e59c969077c0a0168cc13dab5ffc # v1.8.0
+      - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           components: rustfmt
 

--- a/rustfmt/action.yml
+++ b/rustfmt/action.yml
@@ -21,11 +21,11 @@ runs:
   steps:
     - name: Checkout the latest code
       id: git_checkout
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Setup Rust Toolchain
       id: setup_rust_toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10.1
+      uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
       with:
         components: rustfmt
         cache: false

--- a/stacks-core/cache/bitcoin/README.md
+++ b/stacks-core/cache/bitcoin/README.md
@@ -12,12 +12,10 @@ Generic cache operations for the bitcoin cache:
 
 | Input              | Description                                               | Required | Default                                                                   |
 | ------------------ | --------------------------------------------------------- | -------- | ------------------------------------------------------------------------- |
-| `action`           | Type of cache action - one of: `check`, `restore`, `save` | true     | `check`                                                                   |
-| `cache-key`        | Cache Key name                                            | false    | `$${{ github.event.repository.name }}-${{ github.sha }}-bitcoin-binaries` |
-| `fail_ci_if_error` | Fail the workflow on an error                             | false    | `false`                                                                   |
-| `retries`          | Number of times to retry codecov upload                   | false    | `3`                                                                       |
-| `retry-delay`      | Time in ms between upload retries                         | false    | `10000`                                                                   |
-| `btc-version`      | The version of Bitcoin to use                             | false    | `25.0`                                                                    |
+| `action`             | Type of cache action - one of: `check`, `restore`, `save` | true     | `check` |
+| `cache-key`          | Cache Key name                                            | false    | `${{ github.event.repository.name }}-${{ github.event.pull_request.head.sha || github.sha }}-bitcoin-binaries`   |
+| `fail-on-cache-miss` | Fail the workflow if the cache is not found               | false    | `true` |
+| `btc-version`        | The version of Bitcoin to use                             | false    | `25.0` |
 
 ### Outputs
 

--- a/stacks-core/cache/bitcoin/action.yml
+++ b/stacks-core/cache/bitcoin/action.yml
@@ -13,14 +13,6 @@ inputs:
     description: "Fail workflow if cache is not restorable"
     required: false
     default: "true"
-  retries:
-    description: "Number of attempts"
-    required: false
-    default: "3"
-  retry-delay:
-    description: "Time to wait to retry"
-    required: false
-    default: "10000"
   cache-key:
     description: "Cache Key name"
     required: false
@@ -43,7 +35,7 @@ runs:
       if: |
         inputs.action == 'check' ||
         inputs.action == 'save'
-      uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       id: check_cache
       with:
         lookup-only: true
@@ -51,23 +43,17 @@ runs:
         key: ${{ inputs.cache-key }}-${{ inputs.btc-version }}
 
     ## Restore cache data
-    ## Use wretry action, to retry on a failed upload
     - name: Restore Cache
       if: |
         inputs.action == 'restore'
       id: restore_cache
-      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
-        action: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with: |
-          fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
-          path: ~/bitcoin
-          key: ${{ inputs.cache-key }}-${{ inputs.btc-version }}
-        attempt_limit: ${{ inputs.retries}}
-        attempt_delay: ${{ inputs.retry-delay}}
+        fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
+        path: ~/bitcoin
+        key: ${{ inputs.cache-key }}-${{ inputs.btc-version }}
 
-    ## Save cache data
-    ## If cache is not found, download and extract it
+    ## Install Bitcoin binary
     - name: Install Bitcoin Binary
       if: |
         inputs.action == 'save' &&
@@ -78,17 +64,13 @@ runs:
         curl -LSf -# https://github.com/stacks-network/bitcoin/releases/download/v${{ inputs.btc-version }}/bitcoin-${{ inputs.btc-version }}-x86_64-linux-gnu.tar.gz | tar zxf - -C ~
         mv ~/bitcoin-${{ inputs.btc-version }} ~/bitcoin
 
-    ## Use wretry action to retry on a failed upload
+    ## Save cache data
     - name: Save Cache
       if: |
         inputs.action == 'save' &&
         steps.check_cache.outputs.cache-hit != 'true'
       id: save_cache
-      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+      uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
-        action: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with: |
-          path: ~/bitcoin
-          key: ${{ inputs.cache-key }}-${{ inputs.btc-version }}
-        attempt_limit: ${{ inputs.retries}}
-        attempt_delay: ${{ inputs.retry-delay}}
+        path: ~/bitcoin
+        key: ${{ inputs.cache-key }}-${{ inputs.btc-version }}

--- a/stacks-core/cache/build-cache/action.yml
+++ b/stacks-core/cache/build-cache/action.yml
@@ -63,12 +63,12 @@ runs:
     - name: Checkout the latest code
       if: steps.build_plan.outputs.build_required == 'true'
       id: git_checkout
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Setup Rust Toolchain
       if: steps.build_plan.outputs.build_required == 'true'
       id: setup_rust_toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10.1
+      uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
       with:
         components: llvm-tools-preview
         cache: false
@@ -87,7 +87,6 @@ runs:
       run: |
         export RUSTFLAGS="-C instrument-coverage" && \
         cargo nextest archive \
-          --build-jobs 8 \
           --workspace \
           --tests \
           --locked \
@@ -102,7 +101,6 @@ runs:
         export RUSTFLAGS="-C instrument-coverage" && \
         cd stacks-node && \
         cargo nextest archive \
-          --build-jobs 8 \
           --workspace \
           --tests \
           --locked \

--- a/stacks-core/cache/cargo/README.md
+++ b/stacks-core/cache/cargo/README.md
@@ -8,10 +8,8 @@ Caches cargo artifacts (with grcov for code coverage)
 | Input | Description | Required | Default |
 | ------------------------------- | ----------------------------------------------------- | ------------------------- | ------------------------- |
 | `action` | Type of cache action - one of: `check`, `restore`, `save` | true | `check` |
-| `cache-key` | Cache Key name | false | `${{ github.event.repository.name }}-${{ github.sha }}-test-archive` |
-| `fail_ci_if_error` | Fail the workflow on an error | false | `false` |
-| `retries` | Number of times to retry codecov upload | false | `3` |
-| `retry-delay` | Time in ms between upload retries | false | `10000` |
+| `cache-key` | Cache Key name | false | `${{ github.event.repository.name }}-${{ github.sha || github.event.pull_request.head.sha }}-cargo` |
+| `fail-on-cache-miss` | Fail the workflow when cache is not found | false | `true` |
 
 ### Outputs
 | Output | Description |

--- a/stacks-core/cache/cargo/action.yml
+++ b/stacks-core/cache/cargo/action.yml
@@ -13,14 +13,6 @@ inputs:
     description: "Fail workflow if cache is not restorable"
     required: false
     default: "true"
-  retries:
-    description: "Number of attempts"
-    required: false
-    default: "3"
-  retry-delay:
-    description: "Time to wait to retry"
-    required: false
-    default: "10000"
   cache-key:
     description: "Cache Key name"
     required: false
@@ -39,7 +31,7 @@ runs:
       if: |
         inputs.action == 'check' ||
         inputs.action == 'save'
-      uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       id: check_cache
       with:
         lookup-only: true
@@ -51,25 +43,20 @@ runs:
         key: ${{ inputs.cache-key }}
 
     ## Restore cache data
-    ## Use wretry action, to retry on a failed upload
     - name: Restore Cache
       if: |
         inputs.action == 'restore'
       id: restore_cache
-      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
-        action: actions/cache/restore@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
-        with: |
-          fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ inputs.cache-key }}
-        attempt_limit: ${{ inputs.retries}}
-        attempt_delay: ${{ inputs.retry-delay}}
-
+        fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: ${{ inputs.cache-key }}
+        
     ## Restore cache data
     ## If cache is not found, install nextest
     - name: Install nextest
@@ -91,21 +78,17 @@ runs:
       with:
         tool: grcov # can be versioned, ex: tool@1.1.1.1
 
-    ## Use wretry action to retry on a failed upload
+    ## Save cache data
     - name: Save Cache
       if: |
         inputs.action == 'save' &&
         steps.check_cache.outputs.cache-hit != 'true'
       id: save_cache
-      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+      uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
-        action: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with: |
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ inputs.cache-key }}
-        attempt_limit: ${{ inputs.retries}}
-        attempt_delay: ${{ inputs.retry-delay}}
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: ${{ inputs.cache-key }}

--- a/stacks-core/cache/genesis-test-archive/README.md
+++ b/stacks-core/cache/genesis-test-archive/README.md
@@ -13,10 +13,8 @@
 | Input | Description | Required | Default |
 | ------------------------------- | ----------------------------------------------------- | ------------------------- | ------------------------- |
 | `action` | Type of cache action - one of: `check`, `restore`, `save` | true | `check` |
-| `cache-key` | Cache Key name | false | `${{ github.event.repository.name }}-${{ github.sha }}-test-archive` |
-| `fail_ci_if_error` | Fail the workflow on an error | false | `false` |
-| `retries` | Number of times to retry codecov upload | false | `3` |
-| `retry-delay` | Time in ms between upload retries | false | `10000` |
+| `cache-key` | Cache Key name | false | `${{ github.event.repository.name }}-${{ github.event.pull_request.head.sha || github.sha }}-genesis-test-archive` |
+| `fail-on-cache-miss` | Fail the workflow if the cache is not found | false | `true` |
 
 ### Outputs
 

--- a/stacks-core/cache/genesis-test-archive/action.yml
+++ b/stacks-core/cache/genesis-test-archive/action.yml
@@ -13,14 +13,6 @@ inputs:
     description: "Fail workflow if cache is not restorable"
     required: false
     default: "true"
-  retries:
-    description: "Number of attempts"
-    required: false
-    default: "3"
-  retry-delay:
-    description: "Time to wait to retry"
-    required: false
-    default: "10000"
   cache-key:
     description: "Cache Key name"
     required: false
@@ -39,7 +31,7 @@ runs:
       if: |
         inputs.action == 'check' ||
         inputs.action == 'save'
-      uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       id: check_cache
       with:
         lookup-only: true
@@ -47,33 +39,23 @@ runs:
         key: ${{ inputs.cache-key }}
 
     ## Restore cache data
-    ## Use wretry action, to retry on a failed upload
     - name: Restore Cache
       if: |
         inputs.action == 'restore'
       id: restore_cache
-      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
-        action: actions/cache/restore@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
-        with: |
-          fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
-          path: ~/genesis_archive.tar.zst
-          key: ${{ inputs.cache-key }}
-        attempt_limit: ${{ inputs.retries}}
-        attempt_delay: ${{ inputs.retry-delay}}
+        fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
+        path: ~/genesis_archive.tar.zst
+        key: ${{ inputs.cache-key }}
 
     ## Save cache data
-    ## Use wretry action to retry on a failed upload
     - name: Save Cache
       if: |
         inputs.action == 'save' &&
         steps.check_cache.outputs.cache-hit != 'true'
       id: save_cache
-      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+      uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
-        action: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with: |
-          path: ~/genesis_archive.tar.zst
-          key: ${{ inputs.cache-key }}
-        attempt_limit: ${{ inputs.retries}}
-        attempt_delay: ${{ inputs.retry-delay}}
+        path: ~/genesis_archive.tar.zst
+        key: ${{ inputs.cache-key }}

--- a/stacks-core/cache/target/README.md
+++ b/stacks-core/cache/target/README.md
@@ -9,10 +9,8 @@ Caches cargo target artifacts
 | Input | Description | Required | Default |
 | ------------------------------- | ----------------------------------------------------- | ------------------------- | ------------------------- |
 | `action` | Type of cache action - one of: `check`, `restore`, `save` | true | `check` |
-| `cache-key` | Cache Key name | false | `${{ github.event.repository.name }}-${{ github.sha }}-test-archive` |
-| `fail_ci_if_error` | Fail the workflow on an error | false | `false` |
-| `retries` | Number of times to retry codecov upload | false | `3` |
-| `retry-delay` | Time in ms between upload retries | false | `10000` |
+| `cache-key` | Cache Key name | false | `${{ github.event.repository.name }}-${{ github.sha || github.event.pull_request.head.sha }}-target` |
+| `fail-on-cache-miss` | Fail the workflow on an error | false | `true` |
 
 ### Outputs
 

--- a/stacks-core/cache/target/action.yml
+++ b/stacks-core/cache/target/action.yml
@@ -13,14 +13,6 @@ inputs:
     description: "Fail workflow if cache is not restorable"
     required: false
     default: "true"
-  retries:
-    description: "Number of attempts"
-    required: false
-    default: "3"
-  retry-delay:
-    description: "Time to wait to retry"
-    required: false
-    default: "10000"
   cache-key:
     description: "Cache Key name"
     required: false
@@ -38,7 +30,7 @@ runs:
     - name: Check Cache
       if: |
         inputs.action == 'check'
-      uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       id: check_cache
       with:
         lookup-only: true
@@ -46,32 +38,22 @@ runs:
         key: ${{ inputs.cache-key }}
 
     ## Restore cache data
-    ## Use wretry action, to retry on a failed upload
     - name: Restore Cache
       if: |
         inputs.action == 'restore'
       id: restore_cache
-      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
-        action: actions/cache/restore@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
-        with: |
-          fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
-          path: ./target
-          key: ${{ inputs.cache-key }}
-        attempt_limit: ${{ inputs.retries}}
-        attempt_delay: ${{ inputs.retry-delay}}
+        fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
+        path: ./target
+        key: ${{ inputs.cache-key }}
 
     ## Save cache data
-    ## Use wretry action to retry on a failed upload
     - name: Save Cache
       if: |
         inputs.action == 'save'
       id: save_cache
-      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+      uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
-        action: actions/cache/save@05a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with: |
-          path: ./target
-          key: ${{ inputs.cache-key }}
-        attempt_limit: ${{ inputs.retries}}
-        attempt_delay: ${{ inputs.retry-delay}}
+        path: ./target
+        key: ${{ inputs.cache-key }}

--- a/stacks-core/cache/test-archive/README.md
+++ b/stacks-core/cache/test-archive/README.md
@@ -13,10 +13,8 @@
 | Input | Description | Required | Default |
 | ------------------------------- | ----------------------------------------------------- | ------------------------- | ------------------------- |
 | `action` | Type of cache action - one of: `check`, `restore`, `save` | true | `check` |
-| `cache-key` | Cache Key name | false | `${{ github.event.repository.name }}-${{ github.sha }}-test-archive` |
-| `fail_ci_if_error` | Fail the workflow on an error | false | `false` |
-| `retries` | Number of times to retry codecov upload | false | `3` |
-| `retry-delay` | Time in ms between upload retries | false | `10000` |
+| `cache-key` | Cache Key name | false | `${{ github.event.repository.name }}-${{ github.event.pull_request.head.sha || github.sha }}-test-archive` |
+| `fail-on-cache-miss` | Fail the workflow if the cache is not found | false | `true` |
 
 ### Outputs
 

--- a/stacks-core/cache/test-archive/action.yml
+++ b/stacks-core/cache/test-archive/action.yml
@@ -13,14 +13,6 @@ inputs:
     description: "Fail workflow if cache is not restorable"
     required: false
     default: "true"
-  retries:
-    description: "Number of attempts"
-    required: false
-    default: "3"
-  retry-delay:
-    description: "Time to wait to retry"
-    required: false
-    default: "10000"
   cache-key:
     description: "Cache Key name"
     required: false
@@ -39,7 +31,7 @@ runs:
       if: |
         inputs.action == 'check' ||
         inputs.action == 'save'
-      uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       id: check_cache
       with:
         lookup-only: true
@@ -47,33 +39,24 @@ runs:
         key: ${{ inputs.cache-key }}
 
     ## Restore cache data
-    ## Use wretry action, to retry on a failed upload
     - name: Restore Cache
       if: |
         inputs.action == 'restore'
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       id: restore_cache
-      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
       with:
-        action: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with: |
-          fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
-          path: ~/test_archive.tar.zst
-          key: ${{ inputs.cache-key }}
-        attempt_limit: ${{ inputs.retries}}
-        attempt_delay: ${{ inputs.retry-delay}}
+        fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
+        path: ~/test_archive.tar.zst
+        key: ${{ inputs.cache-key }}
 
     ## Save cache data
-    ## Use wretry action to retry on a failed upload
     - name: Save Cache
       if: |
         inputs.action == 'save' &&
         steps.check_cache.outputs.cache-hit != 'true'
       id: save_cache
-      uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+      uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
-        action: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with: |
-          path: ~/test_archive.tar.zst
-          key: ${{ inputs.cache-key }}
-        attempt_limit: ${{ inputs.retries}}
-        attempt_delay: ${{ inputs.retry-delay}}
+        path: ~/test_archive.tar.zst
+        key: ${{ inputs.cache-key }}
+ 

--- a/stacks-core/node-config-docsgen/action.yml
+++ b/stacks-core/node-config-docsgen/action.yml
@@ -32,12 +32,12 @@ runs:
     ## Checkout the code
     - name: Checkout the latest code
       id: git_checkout
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     ## Install Rust nightly toolchain (required for rustdoc JSON output)
     - name: Install Rust nightly toolchain
       id: install_rust
-      uses: actions-rust-lang/setup-rust-toolchain@fb51252c7ba57d633bc668f941da052e410add48 # v1.13.0
+      uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
       with:
         toolchain: ${{ inputs.rust-nightly-version }}
         components: rust-docs-json

--- a/stacks-core/release/check-release/action.yml
+++ b/stacks-core/release/check-release/action.yml
@@ -31,7 +31,7 @@ runs:
   steps:
     - name: Checkout the latest code
       id: git_checkout
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set Release Outputs
       id: check_release

--- a/stacks-core/release/downstream-pr/action.yml
+++ b/stacks-core/release/downstream-pr/action.yml
@@ -15,7 +15,7 @@ runs:
   steps:
     - name: Checkout the latest code
       id: git_checkout
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
         ref: ${{ github.ref_name }}

--- a/stacks-core/run-tests/README.md
+++ b/stacks-core/run-tests/README.md
@@ -13,7 +13,8 @@ For running tests using a partition, [use this action ](./partition/) instead.
 | `test-name`      | Test name to run              | `true`   | null                     |
 | `archive-file`   | Archive file to use for tests | `true`   | `~/test_archive.tar.zst` |
 | `threads`        | Number of test threads        | `false`  | `num-cpus`               |
-| `success-output` | Success output                | `false`  | `immediate-final`        |
+| `failure-output` | Failure output                | `false`  | `final`                  |
+| `success-output` | Success output                | `false`  | `never`                  |
 | `status-level`   | Output status level           | `false`  | `fail`                   |
 | `retries`        | Number of test retries        | `false`  | `2`                      |
 

--- a/stacks-core/run-tests/action.yml
+++ b/stacks-core/run-tests/action.yml
@@ -16,10 +16,14 @@ inputs:
     description: "Archive file to use for tests"
     required: true
     default: "~/test_archive.tar.zst"
+  failure-output:
+    description: "Failure output"
+    required: false
+    default: "final"
   success-output:
     description: "Success output"
     required: false
-    default: "immediate-final"
+    default: "never"
   status-level:
     description: "Output status level"
     required: false
@@ -38,12 +42,12 @@ runs:
       run: |
         export LLVM_PROFILE_FILE="test-results-%p-%m.profraw" && \
         cargo nextest run \
-          --verbose \
           --archive-file ${{ inputs.archive-file }} \
           ${{ inputs.threads == '1' && '--no-capture' || format('--test-threads {0}', inputs.threads) }} \
           --retries ${{ inputs.retries }} \
           --run-ignored all \
           --fail-fast \
+          ${{ inputs.threads != '1' && format('--failure-output {0}', inputs.failure-output) || '' }} \
           ${{ inputs.threads != '1' && format('--success-output {0}', inputs.success-output) || '' }} \
           --status-level ${{ inputs.status-level }} \
           -E "test(=${{ inputs.test-name }})"

--- a/stacks-core/run-tests/partition/README.md
+++ b/stacks-core/run-tests/partition/README.md
@@ -12,7 +12,8 @@ Runs stacks-core tests using a [nextest](https://nexte.st) archive with a [parti
 | `total-partitions` | Total number of partitions    | `true`   | null                     |
 | `archive-file`     | Archive file to use for tests | `true`   | `~/test_archive.tar.zst` |
 | `threads`          | Number of test threads        | `false`  | `num-cpus`               |
-| `success-output`   | Success output                | `false`  | `immediate-final`        |
+| `failure-output`   | Failure output                | `false`  | `final`                  |
+| `success-output`   | Success output                | `false`  | `never`                  |
 | `status-level`     | Output status level           | `false`  | `fail`                   |
 | `retries`          | Number of test retries        | `false`  | `2`                      |
 

--- a/stacks-core/run-tests/partition/action.yml
+++ b/stacks-core/run-tests/partition/action.yml
@@ -19,10 +19,14 @@ inputs:
     description: "Archive file to use for tests"
     required: true
     default: "~/test_archive.tar.zst"
+  failure-output:
+    description: "Failure output"
+    required: false
+    default: "final"
   success-output:
     description: "Success output"
     required: false
-    default: "immediate-final"
+    default: "never"
   status-level:
     description: "Output status level"
     required: false
@@ -43,8 +47,8 @@ runs:
         cargo nextest run \
           --test-threads ${{ inputs.threads}} \
           --retries ${{ inputs.retries }} \
-          --final-status-level ${{ inputs.status-level }} \
           --fail-fast \
+          --failure-output ${{ inputs.failure-output }} \
           --success-output ${{ inputs.success-output }} \
           --status-level ${{ inputs.status-level }} \
           --archive-file ${{ inputs.archive-file }} \

--- a/stacks-core/testenv/action.yml
+++ b/stacks-core/testenv/action.yml
@@ -20,14 +20,14 @@ runs:
     ## Checkout the code
     - name: Checkout the latest code
       id: git_checkout
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
 
     ## Install rust toolchain (llvm-tools-preview)
     - name: Setup Rust Toolchain
       id: setup_rust_toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1.10.1
+      uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
       with:
         components: llvm-tools-preview
         cache: false


### PR DESCRIPTION
## Description

Updated many action versions, removed usage of wretry, updated READMEs, and removed --build-jobs flag from build-cache actions because it was set to 8 on runners with 4 CPUs which is bad.

## Type of Change

- Other 

## Does this introduce a breaking change?

No

## Are documentation updates required?

Yes, and the appropriate README files have been updated.

## Testing information

Run GitHub CI Actions in `stacks-core`

## Checklist

N/A