### PR TITLE
Enable all tests to run parallelized when possible, but also output in standard "success never, fail final" stdout settings

### DIFF
--- a/stacks-core/run-tests/README.md
+++ b/stacks-core/run-tests/README.md
@@ -12,7 +12,6 @@ For running tests using a partition, [use this action ](./partition/) instead.
 | ---------------- | ----------------------------- | -------- | ------------------------ |
 | `test-name`      | Test name to run              | `true`   | null                     |
 | `archive-file`   | Archive file to use for tests | `true`   | `~/test_archive.tar.zst` |
-| `threads`        | Number of test threads        | `false`  | `num-cpus`               |
 | `failure-output` | Failure output                | `false`  | `final`                  |
 | `success-output` | Success output                | `false`  | `never`                  |
 | `status-level`   | Output status level           | `false`  | `fail`                   |

--- a/stacks-core/run-tests/action.yml
+++ b/stacks-core/run-tests/action.yml
@@ -8,10 +8,6 @@ inputs:
   test-name:
     description: "Test name to run"
     required: true
-  threads:
-    description: "Number of test threads"
-    required: false
-    default: "num-cpus"
   archive-file:
     description: "Archive file to use for tests"
     required: true
@@ -43,11 +39,10 @@ runs:
         export LLVM_PROFILE_FILE="test-results-%p-%m.profraw" && \
         cargo nextest run \
           --archive-file ${{ inputs.archive-file }} \
-          ${{ inputs.threads == '1' && '--no-capture' || format('--test-threads {0}', inputs.threads) }} \
           --retries ${{ inputs.retries }} \
           --run-ignored all \
           --fail-fast \
-          ${{ inputs.threads != '1' && format('--failure-output {0}', inputs.failure-output) || '' }} \
-          ${{ inputs.threads != '1' && format('--success-output {0}', inputs.success-output) || '' }} \
+          --failure-output ${{ inputs.failure-output }} \
+          --success-output ${{ inputs.success-output }} \
           --status-level ${{ inputs.status-level }} \
           -E "test(=${{ inputs.test-name }})"

--- a/stacks-core/run-tests/partition/README.md
+++ b/stacks-core/run-tests/partition/README.md
@@ -11,7 +11,6 @@ Runs stacks-core tests using a [nextest](https://nexte.st) archive with a [parti
 | `partition`        | Partition to run              | `true`   | null                     |
 | `total-partitions` | Total number of partitions    | `true`   | null                     |
 | `archive-file`     | Archive file to use for tests | `true`   | `~/test_archive.tar.zst` |
-| `threads`          | Number of test threads        | `false`  | `num-cpus`               |
 | `failure-output`   | Failure output                | `false`  | `final`                  |
 | `success-output`   | Success output                | `false`  | `never`                  |
 | `status-level`     | Output status level           | `false`  | `fail`                   |

--- a/stacks-core/run-tests/partition/action.yml
+++ b/stacks-core/run-tests/partition/action.yml
@@ -11,10 +11,6 @@ inputs:
   total-partitions:
     description: "Total number of partitions"
     required: true
-  threads:
-    description: "Number of test threads"
-    required: false
-    default: "num-cpus"
   archive-file:
     description: "Archive file to use for tests"
     required: true
@@ -45,7 +41,6 @@ runs:
       run: |
         export LLVM_PROFILE_FILE="test-results-%p-%m.profraw" && \
         cargo nextest run \
-          --test-threads ${{ inputs.threads}} \
           --retries ${{ inputs.retries }} \
           --fail-fast \
           --failure-output ${{ inputs.failure-output }} \


### PR DESCRIPTION
## Description

Enable all tests to run parallelized when possible, but also output in standard "success never, fail final" stdout settings

## Type of Change

- Other 

## Does this introduce a breaking change?

- No

## Are documentation updates required?

- No

## Testing information

- Run GH actions against `stacks-core`

## Checklist

N/A